### PR TITLE
feat(tenants): per-tenant mail allowlist + opt-in /metrics+/ready auth (#3499)

### DIFF
--- a/backend/alembic/versions/0101_add_tenant_mail_recipient_allowlist.py
+++ b/backend/alembic/versions/0101_add_tenant_mail_recipient_allowlist.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tenant mail-recipient allowlist (#3499).
+
+Revision ID: 0101
+Revises: 0100
+Create Date: 2026-09-08
+
+Task #3499 (Envision isolation, meho-internal#320). Ships the per-tenant
+narrowing override for the ``mail.*`` connector's recipient floor. Today
+``MAIL_RECIPIENT_ALLOWLIST`` is a single instance-wide env, so on a shared
+instance an approved ``mail.send`` in one tenant can deliver to the recipients
+another tenant configured. This column lets an operator pin a tenant to no mail
+(or a narrower recipient set) while other tenants keep their alert mail.
+
+What this migration adds
+------------------------
+
+``tenant.mail_recipient_allowlist`` -- a nullable ``Text`` column carrying a
+tri-state on the *value*, not a Boolean:
+
+* ``NULL`` (default) -- **inherit**: no per-tenant narrowing; the deployment
+  ``MAIL_RECIPIENT_ALLOWLIST`` instance floor alone governs this tenant's
+  dispatched ``mail.send``.
+* ``""`` (empty string) -- **deny**: the tenant's parsed allowlist is empty, so
+  every dispatched ``mail.send`` for this tenant is refused (the inverted
+  "empty ⇒ inert" default the instance floor already uses).
+* a comma-separated address/domain string -- the recipients this tenant may
+  mail, still intersected with the instance floor at the transport (a tenant
+  can only narrow, never widen past the floor).
+
+Read per dispatch by the cache-aware resolver in
+``meho_backplane.connectors.mail.tenant_policy`` and mutated through
+``PATCH /api/v1/tenants/mail-recipient-policy`` (tenant_admin). The checks
+notifier's direct-import ``send_email`` path is not tenant-dispatched and keeps
+only the instance floor.
+
+Additive-only, per the migration-compatibility house rule -- one ``ADD COLUMN``
+on ``tenant``, no ALTER of an existing column and no data rewrite. The column is
+**nullable** (NULL = inherit), so the add-column needs no backfill and is safe
+on a populated table.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the single added column. SQLite ALTER-TABLE drop-column
+is supported since 3.35.0 (we run 3.45+), so Alembic batch-mode is not required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0101"
+down_revision: str | None = "0100"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Per-tenant mail-recipient allowlist (#3499). Nullable Text, so no
+    # backfill -- existing tenants keep NULL (= inherit the instance floor),
+    # preserving today's behaviour with no value change.
+    op.add_column(
+        "tenant",
+        sa.Column("mail_recipient_allowlist", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tenant", "mail_recipient_allowlist")

--- a/backend/src/meho_backplane/api/v1/tenants.py
+++ b/backend/src/meho_backplane/api/v1/tenants.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Operator mutation surface for the per-tenant flight-recorder policy (#3272).
+"""Operator mutation surface for per-tenant policy (#3272, #3499).
+
+Two policy families live here, each its own ``PATCH`` under
+``/api/v1/tenants``: the flight-recorder capture policy (#3272, below) and the
+mail-recipient allowlist (#3499, :func:`update_mail_recipient_policy`). Both
+share the surface posture and scope rules documented next.
+
+Flight-recorder policy (#3272).
 
 The flight-recorder decision (``docs/decisions/dispatch-flight-recorder.md``,
 F1) models capture enablement as an operator action -- "a lab-class tenant is
@@ -51,6 +58,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.connectors.mail.allowlist import parse_recipient_allowlist
+from meho_backplane.connectors.mail.tenant_policy import invalidate_tenant_mail_policy_cache
 from meho_backplane.db.engine import get_session
 from meho_backplane.db.models import Tenant
 from meho_backplane.flight_recorder.config import invalidate_tenant_policy_cache
@@ -215,4 +224,119 @@ async def update_flight_recorder_policy(
         flight_recorder_enabled=tenant.flight_recorder_enabled,
         flight_recorder_agent_readable=tenant.flight_recorder_agent_readable,
         flight_recorder_retention_days=tenant.flight_recorder_retention_days,
+    )
+
+
+class TenantMailRecipientPolicy(BaseModel):
+    """Resolved per-tenant mail-recipient policy -- the PATCH read-back shape (#3499).
+
+    Frozen; maps 1:1 to the tenant's ``mail_recipient_allowlist`` column plus the
+    tenant id. ``mail_recipient_allowlist`` is nullable: ``None`` means
+    **inherit** (no per-tenant narrowing; the deployment-level
+    ``MAIL_RECIPIENT_ALLOWLIST`` instance floor alone governs the send), ``""``
+    means **deny** (an empty tenant allowlist refuses every dispatched
+    ``mail.send``), and a comma-separated string is the tenant's own recipient
+    space (still intersected with the instance floor at the transport).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tenant_id: UUID
+    mail_recipient_allowlist: str | None
+
+
+class TenantMailRecipientPolicyUpdate(BaseModel):
+    """``PATCH /api/v1/tenants/mail-recipient-policy`` body (#3499).
+
+    The single field is optional-partial (``model_dump(exclude_unset=True)`` in
+    the handler keys off ``model_fields_set``, so a JSON ``null`` is
+    distinguished from an absent key). ``extra='forbid'`` rejects unknown keys
+    with a 422.
+
+    * absent = leave the column unchanged.
+    * ``null`` = clear back to **inherit** (the instance floor alone governs the
+      tenant's ``mail.send``).
+    * ``""`` = **deny** (an empty tenant allowlist refuses every dispatched
+      send) -- the shared-instance containment lever.
+    * a comma-separated address/domain string = the tenant's own recipient
+      space. Validated with the same grammar as the instance floor
+      (:func:`~meho_backplane.connectors.mail.allowlist.parse_recipient_allowlist`),
+      so a malformed entry (whitespace, ``foo@``, bare ``@``, ...) is a 422 at
+      write time rather than a silent inert allowlist at dispatch time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mail_recipient_allowlist: str | None = None
+
+    @field_validator("mail_recipient_allowlist")
+    @classmethod
+    def _validate_allowlist_grammar(cls, value: str | None) -> str | None:
+        """Reject a malformed non-null allowlist string at write time.
+
+        ``None`` (clear-to-inherit) and ``""`` (deny) are always legal. A
+        non-empty string must parse under the recipient-allowlist grammar; the
+        parser raises :class:`ValueError` naming the offending token, which
+        Pydantic surfaces as a 422 -- so an operator learns the entry is
+        unusable now instead of discovering later that the tenant silently
+        cannot send. The validator fires only for a *provided* field, so an
+        absent key (leave-unchanged) never reaches it.
+        """
+        if value is None or value == "":
+            return value
+        parse_recipient_allowlist(value)  # raises ValueError -> 422 on a bad entry
+        return value
+
+
+@router.patch("/mail-recipient-policy", response_model=TenantMailRecipientPolicy)
+async def update_mail_recipient_policy(
+    body: TenantMailRecipientPolicyUpdate,
+    operator: Operator = _require_tenant_admin,
+    session: AsyncSession = Depends(get_session),
+) -> TenantMailRecipientPolicy:
+    """Set or clear the caller's per-tenant mail-recipient allowlist (#3499).
+
+    Tenant-scoped to ``operator.tenant_id`` (no cross-tenant write is
+    expressible -- no tenant id is accepted in the path or body).
+    ``tenant_admin`` only. Applies the field only when present in the body; an
+    applied change is folded into this request's ``audit_log`` row (field / old
+    / new, ``None`` -> ``inherit`` sentinel) and evicts the resolver's
+    per-tenant cache so the new value governs the next dispatched ``mail.send``
+    without a restart.
+    """
+    tenant = await session.get(Tenant, operator.tenant_id)
+    if tenant is None:
+        # Defensive depth, mirroring the flight-recorder route: the
+        # ``ensure_tenant`` middleware get-or-creates the row on every
+        # authenticated request, so this only fires if that invariant is ever
+        # bypassed -- surface it structured rather than 500-ing on the setattr.
+        raise HTTPException(status_code=404, detail="tenant_not_found")
+
+    updates = body.model_dump(exclude_unset=True)
+    changed = False
+    if "mail_recipient_allowlist" in updates:
+        new_value = updates["mail_recipient_allowlist"]
+        old_value = tenant.mail_recipient_allowlist
+        if old_value != new_value:
+            tenant.mail_recipient_allowlist = new_value
+            structlog.contextvars.bind_contextvars(
+                audit_mail_recipient_allowlist_before=_audit_value(old_value),
+                audit_mail_recipient_allowlist_after=_audit_value(new_value),
+            )
+            changed = True
+
+    if changed:
+        structlog.contextvars.bind_contextvars(
+            audit_mail_recipient_policy_changed=True,
+            audit_tenant_id=str(operator.tenant_id),
+        )
+        invalidate_tenant_mail_policy_cache(operator.tenant_id)
+        _log.info(
+            "tenant_mail_recipient_policy_updated",
+            tenant_id=str(operator.tenant_id),
+        )
+
+    return TenantMailRecipientPolicy(
+        tenant_id=tenant.id,
+        mail_recipient_allowlist=tenant.mail_recipient_allowlist,
     )

--- a/backend/src/meho_backplane/connectors/mail/allowlist.py
+++ b/backend/src/meho_backplane/connectors/mail/allowlist.py
@@ -30,8 +30,17 @@ receiving host, but no practical mail system distinguishes
 an operator's capitalization habit into a silent refusal.
 
 There is deliberately no pattern/glob dimension (#1177: one closed-set
-config, no DSL) and no per-tenant allowlist — the SMTP block is
-deployment-level (one MTA, one floor), per task #2717's scope.
+config, no DSL). The SMTP block itself is deployment-level (one MTA, one
+floor). A **per-tenant narrowing** override rides on top of this floor
+(#3499): :mod:`meho_backplane.connectors.mail.tenant_policy` resolves a
+tenant's own allowlist and the ``mail.send`` handler screens recipients
+against it *before* this instance floor, so a tenant can be pinned to no
+mail (or a narrower recipient set) while others keep alert mail. That
+override reuses the parser and matcher here — see
+:func:`parse_recipient_allowlist` (``raw`` argument) and
+:func:`recipient_allowed`. The instance floor stays the hard floor on
+every path either way: the tenant screen can only *narrow*, never widen
+past it.
 """
 
 from __future__ import annotations
@@ -42,6 +51,7 @@ __all__ = [
     "RecipientNotAllowedError",
     "assert_recipient_allowed",
     "parse_recipient_allowlist",
+    "recipient_allowed",
 ]
 
 
@@ -64,14 +74,24 @@ def _malformed_entry(entry: str) -> ValueError:
     )
 
 
-def parse_recipient_allowlist() -> tuple[frozenset[str], frozenset[str]]:
-    """Parse ``mail_recipient_allowlist`` into ``(addresses, domains)``.
+def parse_recipient_allowlist(
+    raw: str | None = None,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Parse a recipient allowlist string into ``(addresses, domains)``.
 
     A token containing ``@`` in an interior position is a full address;
     a token without one (or with only a leading ``@``) is a domain. Both
     are lower-cased, and a trailing dot on a domain is stripped, so
     matching is case-insensitive and FQDN-dot-tolerant (mirrors the
     ``net.*`` hostname fold).
+
+    *raw* is the source string. When ``None`` (the default) the live
+    :class:`~meho_backplane.settings.Settings` singleton's
+    ``mail_recipient_allowlist`` (the deployment-level instance floor) is
+    read per call; tests swap that value by mutating the env and clearing
+    ``get_settings``'s cache. Pass an explicit string to parse a
+    **per-tenant** override (#3499) instead — the same grammar, so a
+    malformed tenant entry fails as loudly as a malformed instance entry.
 
     A token that is not a well-formed address or domain raises
     :class:`ValueError` naming it — loud, because silently keeping an
@@ -85,14 +105,11 @@ def parse_recipient_allowlist() -> tuple[frozenset[str], frozenset[str]]:
     look non-empty — suppressing the "connector is inert" refusal
     message that would otherwise tell the operator exactly what is
     wrong.
-
-    Reads the live :class:`~meho_backplane.settings.Settings` singleton
-    per call; tests swap the value by mutating the env and clearing
-    ``get_settings``'s cache, like every other settings-backed surface.
     """
+    source = get_settings().mail_recipient_allowlist if raw is None else raw
     addresses: set[str] = set()
     domains: set[str] = set()
-    for token in get_settings().mail_recipient_allowlist.split(","):
+    for token in source.split(","):
         entry = token.strip()
         if not entry:
             continue
@@ -112,11 +129,59 @@ def parse_recipient_allowlist() -> tuple[frozenset[str], frozenset[str]]:
     return frozenset(addresses), frozenset(domains)
 
 
+def _normalise_recipient(address: str) -> str | None:
+    """Return the folded ``local@domain`` candidate, or ``None`` if unparseable.
+
+    An address is unparseable — and therefore never matches any allowlist —
+    when it is empty, carries whitespace or non-printable characters, or is
+    not exactly one ``local@domain`` pair. Refusing an unparseable recipient
+    (rather than guessing) is what keeps SMTP envelope injection (CR/LF in a
+    recipient) structurally impossible past this gate.
+    """
+    candidate = address.strip().lower()
+    local, sep, domain = candidate.partition("@")
+    if (
+        not local
+        or not sep
+        or not domain
+        or "@" in domain
+        or any(ch.isspace() or not ch.isprintable() for ch in candidate)
+    ):
+        return None
+    return candidate
+
+
+def recipient_allowed(
+    address: str,
+    addresses: frozenset[str],
+    domains: frozenset[str],
+) -> bool:
+    """Return whether *address* is covered by a parsed ``(addresses, domains)`` set.
+
+    The pure membership predicate underneath both floors: an empty set
+    (``not addresses and not domains``) admits nothing (the inverted
+    "empty ⇒ inert / deny" default), an unparseable address matches
+    nothing, and otherwise the folded address must be a listed full
+    address or sit at a listed domain. Used verbatim by the transport's
+    instance-floor :func:`assert_recipient_allowed` and by the
+    per-tenant screen in :mod:`meho_backplane.connectors.mail.ops`
+    (#3499), so both floors decide membership identically.
+    """
+    if not addresses and not domains:
+        return False
+    candidate = _normalise_recipient(address)
+    if candidate is None:
+        return False
+    _, _, domain = candidate.partition("@")
+    return candidate in addresses or domain.rstrip(".") in domains
+
+
 def assert_recipient_allowed(address: str) -> None:
     """Raise :class:`RecipientNotAllowedError` unless *address* is allowlisted.
 
     Called by the transport on **every** recipient of a send, *before*
-    any SMTP connection opens. The decision is absolute membership in
+    any SMTP connection opens, against the **instance floor**
+    (``MAIL_RECIPIENT_ALLOWLIST``). The decision is absolute membership in
     :func:`parse_recipient_allowlist`'s parsed set:
 
     * empty allowlist → always refuse (the connector is inert);
@@ -130,6 +195,10 @@ def assert_recipient_allowed(address: str) -> None:
     recipient) structurally impossible past this gate. The message never
     echoes the parsed set (no recipient-space oracle).
 
+    Membership is decided by :func:`recipient_allowed`; the empty-allowlist
+    and malformed-address arms are split out here only so each raises its
+    own diagnostic message.
+
     Raises:
         RecipientNotAllowedError: *address* is empty, malformed, not
             covered by the allowlist, or the allowlist is empty.
@@ -140,17 +209,9 @@ def assert_recipient_allowed(address: str) -> None:
             "recipient refused: MAIL_RECIPIENT_ALLOWLIST is empty, so the "
             "mail.* connector is inert; add the address or domain to mail"
         )
-    candidate = address.strip().lower()
-    local, sep, domain = candidate.partition("@")
-    if (
-        not local
-        or not sep
-        or not domain
-        or "@" in domain
-        or any(ch.isspace() or not ch.isprintable() for ch in candidate)
-    ):
+    if _normalise_recipient(address) is None:
         raise RecipientNotAllowedError(f"recipient refused: {address!r} is not a valid address")
-    if candidate in addresses or domain.rstrip(".") in domains:
+    if recipient_allowed(address, addresses, domains):
         return
     raise RecipientNotAllowedError(
         "recipient refused: address is not listed in MAIL_RECIPIENT_ALLOWLIST"

--- a/backend/src/meho_backplane/connectors/mail/ops.py
+++ b/backend/src/meho_backplane/connectors/mail/ops.py
@@ -36,12 +36,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final
 
+import structlog
+
+from meho_backplane.connectors.mail.allowlist import recipient_allowed
+from meho_backplane.connectors.mail.tenant_policy import resolve_tenant_recipient_allowlist
 from meho_backplane.connectors.mail.transport import send_email
 from meho_backplane.operations.typed_register import register_typed_operation
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
     from meho_backplane.retrieval.embedding import EmbeddingService
+
+_log = structlog.get_logger(__name__)
 
 __all__ = [
     "MAIL_SEND_PARAMETER_SCHEMA",
@@ -184,14 +190,44 @@ async def mail_send(operator: Operator, target: Any, params: dict[str, Any]) -> 
 
     Delegates to
     :func:`~meho_backplane.connectors.mail.transport.send_email` (the
-    allowlist floor and refusal mapping live there) and adapts the
-    :class:`~meho_backplane.connectors.mail.transport.MailSendResult`
+    instance-floor allowlist and refusal mapping live there) and adapts
+    the :class:`~meho_backplane.connectors.mail.transport.MailSendResult`
     into the audit-visible payload: the returned dict carries the
     literal ``to``/``subject`` — the durable audit row's ``raw_payload``
     answer to "who was mailed" — and never the body.
+
+    **Per-tenant screen (#3499).** Before the transport runs, every
+    recipient is screened against the caller's per-tenant allowlist
+    (:func:`~meho_backplane.connectors.mail.tenant_policy.resolve_tenant_recipient_allowlist`).
+    A tenant that set no override inherits the instance floor unchanged
+    (resolver returns ``None`` → screen skipped). A tenant with an empty
+    override denies every recipient; a tenant with a narrower list admits
+    only those recipients — always still intersected with the instance
+    floor at the transport, so the screen can only narrow. A refused
+    recipient returns the same ``not_in_recipient_allowlist`` product the
+    instance floor uses, so the dispatch stays ``status="ok"`` and the
+    denial is audited synchronously through the normal path. This screen
+    is only on the **dispatch** path; the checks notifier's direct
+    ``send_email`` import is not tenant-scoped and keeps the instance
+    floor alone.
     """
     to = [str(address) for address in params["to"]]
     subject = str(params["subject"])
+    tenant_allowlist = await resolve_tenant_recipient_allowlist(operator.tenant_id)
+    if tenant_allowlist is not None:
+        addresses, domains = tenant_allowlist
+        if not all(recipient_allowed(address, addresses, domains) for address in to):
+            _log.info(
+                "mail_tenant_recipient_refused",
+                tenant_id=str(operator.tenant_id),
+                recipient_count=len(to),
+            )
+            return {
+                "sent": False,
+                "reason": "not_in_recipient_allowlist",
+                "to": to,
+                "subject": subject,
+            }
     result = await send_email(to=to, subject=subject, body=str(params["body"]))
     return {
         "sent": result.sent,

--- a/backend/src/meho_backplane/connectors/mail/tenant_policy.py
+++ b/backend/src/meho_backplane/connectors/mail/tenant_policy.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tenant mail-recipient allowlist resolver (#3499).
+
+``MAIL_RECIPIENT_ALLOWLIST`` is a single deployment-level instance floor
+(:mod:`meho_backplane.connectors.mail.allowlist`). On a shared instance that
+floor cannot be narrowed per tenant, so an approved ``mail.send`` in one tenant
+can deliver to the recipients another tenant configured. This resolver reads a
+**per-tenant narrowing** override (``tenant.mail_recipient_allowlist``) that the
+``mail.send`` dispatch handler screens recipients against *before* the instance
+floor, letting an operator pin one tenant to no mail while others keep alert
+mail. The override can only narrow: the instance floor is still applied by the
+transport afterwards, so a tenant can never widen its recipient space past it.
+
+Resolution of ``tenant.mail_recipient_allowlist`` (a nullable ``Text`` column):
+
+* ``NULL`` → :data:`None` (**inherit**): no per-tenant screen; the instance
+  floor alone governs the send.
+* ``""`` → ``(frozenset(), frozenset())`` (**deny**): the tenant's parsed
+  allowlist is empty, so :func:`~meho_backplane.connectors.mail.allowlist.recipient_allowed`
+  admits nothing and every dispatched ``mail.send`` for this tenant is refused.
+* a comma-separated address/domain string → the parsed
+  ``(addresses, domains)`` the tenant may mail (still intersected with the
+  instance floor at the transport).
+
+**Fail-closed** — the opposite direction from the flight-recorder resolver's
+fail-open (:mod:`meho_backplane.flight_recorder.config`). Capture is a *record*
+decision where doubt should record less; this is a *delivery-authorization*
+decision where doubt should deliver less. So an unreadable / unparseable policy
+resolves to **deny** (an empty allowlist), never to inherit: falling through to
+the instance floor on a read error would defeat the containment the override
+exists to provide. The deny is not cached, so a transient DB error does not pin
+the tenant to deny for the cache TTL.
+
+Cache discipline mirrors :mod:`meho_backplane.flight_recorder.config`: a 60s
+per-key TTL keeps the policy off the DB on the per-dispatch path; only a miss
+awaits a one-row SELECT. Only successfully-resolved values are cached.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Final
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.connectors.mail.allowlist import parse_recipient_allowlist
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
+
+__all__ = [
+    "invalidate_tenant_mail_policy_cache",
+    "reset_tenant_mail_policy_cache_for_testing",
+    "resolve_tenant_recipient_allowlist",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Per-key TTL, mirroring the flight-recorder / announce-gate resolvers.
+_CACHE_TTL_SECONDS: Final[float] = 60.0
+
+#: Per-tenant resolved-policy cache. Value = (resolved, monotonic_expires_at)
+#: where ``resolved`` is ``None`` (inherit) or the parsed ``(addresses,
+#: domains)`` tuple. A hit is a pure dict lookup; a miss awaits a one-row
+#: SELECT of the single ``mail_recipient_allowlist`` column.
+_TENANT_CACHE: dict[UUID, tuple[tuple[frozenset[str], frozenset[str]] | None, float]] = {}
+
+#: The deny sentinel a fail-closed resolution returns (empty allowlist admits
+#: nothing). Distinct object identity is irrelevant — an empty parsed tuple is
+#: the deny state everywhere in the connector.
+_DENY: Final[tuple[frozenset[str], frozenset[str]]] = (frozenset(), frozenset())
+
+
+def reset_tenant_mail_policy_cache_for_testing() -> None:
+    """Clear the per-tenant cache (test isolation only)."""
+    _TENANT_CACHE.clear()
+
+
+def invalidate_tenant_mail_policy_cache(tenant_id: UUID) -> None:
+    """Evict the cached allowlist for *tenant_id* after an operator policy write.
+
+    The ``PATCH /api/v1/tenants/mail-recipient-policy`` route calls this on a
+    change so the new value takes effect on the next dispatched ``mail.send``
+    instead of waiting out :data:`_CACHE_TTL_SECONDS` (or a restart).
+    Idempotent — popping an absent key is a no-op, so a no-op write can call it
+    safely.
+    """
+    _TENANT_CACHE.pop(tenant_id, None)
+
+
+async def resolve_tenant_recipient_allowlist(
+    tenant_id: UUID,
+) -> tuple[frozenset[str], frozenset[str]] | None:
+    """Return the per-tenant recipient allowlist, or ``None`` to inherit.
+
+    ``None`` means the tenant set no override (``NULL`` column, or no tenant
+    row at all — a brand-new tenant inherits the instance floor). A returned
+    ``(addresses, domains)`` tuple is the tenant's own allowlist; an empty
+    tuple denies every recipient.
+
+    Fail-closed: any error reading or parsing the policy resolves to the deny
+    sentinel (empty tuple) and is **not** cached, so a transient DB error
+    refuses this send without pinning the tenant to deny for the TTL. Cache-
+    aware for the success path.
+    """
+    now = time.monotonic()
+    cached = _TENANT_CACHE.get(tenant_id)
+    if cached is not None and cached[1] > now:
+        return cached[0]
+    try:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            raw = (
+                await session.execute(
+                    select(Tenant.mail_recipient_allowlist).where(Tenant.id == tenant_id)
+                )
+            ).one_or_none()
+        # ``raw is None`` → no tenant row; ``raw[0] is None`` → NULL column.
+        # Both mean "no per-tenant override" → inherit the instance floor.
+        resolved: tuple[frozenset[str], frozenset[str]] | None = (
+            None if raw is None or raw[0] is None else parse_recipient_allowlist(raw[0])
+        )
+    except Exception:
+        _log.warning(
+            "mail_tenant_policy_resolve_failed_deny",
+            tenant_id=str(tenant_id),
+            exc_info=True,
+        )
+        return _DENY
+    _TENANT_CACHE[tenant_id] = (resolved, now + _CACHE_TTL_SECONDS)
+    return resolved

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -770,6 +770,36 @@ class Tenant(Base):
         nullable=True,
         default=None,
     )
+    # Per-tenant mail-recipient allowlist (#3499). A **narrowing** override on
+    # top of the deployment-level ``MAIL_RECIPIENT_ALLOWLIST`` instance floor
+    # (:mod:`meho_backplane.connectors.mail.allowlist`), evaluated in the
+    # ``mail.send`` dispatch handler before the transport's instance screen.
+    # Tri-state, but on a Text column rather than a Boolean:
+    #
+    # * ``NULL`` (default) -- **inherit**: no per-tenant narrowing; the
+    #   instance floor alone governs this tenant's dispatched ``mail.send``.
+    # * ``""`` (empty string) -- **deny**: the tenant's parsed allowlist is
+    #   empty, so every dispatched ``mail.send`` for this tenant is refused
+    #   (same inverted-default "empty ⇒ inert" semantics as the instance
+    #   floor). This is the shared-instance containment lever: an untrusted
+    #   tenant can be pinned to no mail while other tenants keep alert mail.
+    # * a comma-separated address/domain string -- the recipients permitted
+    #   for this tenant, still intersected with the instance floor at the
+    #   transport (a tenant can only narrow, never widen past the floor).
+    #
+    # Read per dispatch by the cache-aware resolver in
+    # :mod:`meho_backplane.connectors.mail.tenant_policy` (fail-**closed** to
+    # deny on a read error, the opposite direction from the flight-recorder
+    # resolver's fail-open: this is a delivery-authorization decision, so doubt
+    # reduces exposure). The checks notifier's direct-import
+    # ``transport.send_email`` path is not tenant-dispatched and keeps only the
+    # instance floor. Nullable, so migration ``0101`` needs no backfill. No
+    # index -- read by primary-key lookup on a cache miss, never a filter.
+    mail_recipient_allowlist: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(

--- a/backend/src/meho_backplane/health.py
+++ b/backend/src/meho_backplane/health.py
@@ -51,10 +51,11 @@ from dataclasses import asdict, dataclass
 from typing import cast
 
 import structlog
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
 from meho_backplane.features import build_features_block
+from meho_backplane.metrics_access import verify_metrics_access
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -525,9 +526,18 @@ async def healthz() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@router.get("/ready")
+@router.get("/ready", dependencies=[Depends(verify_metrics_access)])
 async def ready() -> JSONResponse:
     """Readiness probe with deploy-time feature-gate visibility.
+
+    Guarded by :func:`~meho_backplane.metrics_access.verify_metrics_access`
+    (#3499): open by default, but when ``METRICS_AUTH_TOKEN`` is set the
+    caller must present a matching bearer token or the request is refused
+    401 — so the ``features`` block's four-eyes / feature-gate posture is
+    not readable unauthenticated on a shared ingress. ``/healthz`` (pure
+    liveness) is deliberately left unguarded, so a bearer-less liveness path
+    always exists; a deployment that turns the guard on carries the token on
+    the readiness probe via ``httpHeaders``.
 
     Returns 200 with
     ``{"status": "ready", "checks": [...], "features": {...}}`` when

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -49,7 +49,7 @@ from dataclasses import dataclass
 from typing import Final
 
 import structlog
-from fastapi import FastAPI, Response
+from fastapi import Depends, FastAPI, Response
 from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -173,6 +173,7 @@ from meho_backplane.memory import (
     stop_memory_expiry_sweeper,
 )
 from meho_backplane.metrics import render_metrics
+from meho_backplane.metrics_access import verify_metrics_access
 from meho_backplane.middleware import BroadcastDetailMiddleware, RequestContextMiddleware
 from meho_backplane.operations import run_typed_op_registrars, set_default_reducer
 from meho_backplane.operations.approval_expiry import (
@@ -1349,7 +1350,7 @@ async def root() -> dict[str, str]:
     return {"name": _APP_NAME, "version": __version__}
 
 
-@app.get("/metrics")
+@app.get("/metrics", dependencies=[Depends(verify_metrics_access)])
 async def metrics() -> Response:
     """Prometheus exposition endpoint.
 
@@ -1357,6 +1358,11 @@ async def metrics() -> Response:
     the ``http_requests_total`` counter the middleware increments) in
     the legacy ``text/plain; version=0.0.4`` format that every
     Prometheus scraper understands.
+
+    Guarded by :func:`~meho_backplane.metrics_access.verify_metrics_access`
+    (#3499): open by default, but when ``METRICS_AUTH_TOKEN`` is set the
+    caller must present a matching bearer token or the request is refused
+    401 before any registry content is rendered.
     """
     body, content_type = render_metrics()
     return Response(content=body, media_type=content_type)

--- a/backend/src/meho_backplane/metrics_access.py
+++ b/backend/src/meho_backplane/metrics_access.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Opt-in bearer-token guard for the operational exposition endpoints (#3499).
+
+``GET /metrics`` (:mod:`meho_backplane.main`) and ``GET /ready``
+(:mod:`meho_backplane.health`) are served on the shared ingress. Left
+unauthenticated they leak operational metrics and the effective four-eyes /
+feature-gate posture to anyone who can reach the ingress — on a shared instance
+hosting an untrusted-visitor tenant (the Envision stand, meho-internal#320) that
+is production activity exposed to the public booth.
+
+:func:`verify_metrics_access` is the shared FastAPI dependency both endpoints
+declare. It is **opt-in and default-open**: when
+:attr:`~meho_backplane.settings.Settings.metrics_auth_token` is empty (the
+default) it returns immediately, so behaviour is unchanged and the in-cluster
+scraper + kubelet readiness probe keep working with no config change. When the
+token is set it requires ``Authorization: Bearer <token>`` and refuses anything
+else with ``401``.
+
+Design notes:
+
+* **Bearer, not source-CIDR.** Behind the shared ingress the app sees the proxy
+  IP, not the real client, so a peer-IP CIDR check cannot separate a booth
+  visitor from the scraper without trusting a spoofable ``X-Forwarded-For``. A
+  bearer token is proxy-independent and is the standard Prometheus scrape auth
+  (``bearer_token`` / ServiceMonitor ``bearerTokenSecret``); a kubelet
+  readiness probe carries it via ``httpHeaders``.
+* **``/healthz`` is never guarded.** It is a pure liveness signal (always 200,
+  no posture), so a bearer-less liveness path always exists even when the guard
+  is on.
+* **Constant-time compare** (:func:`secrets.compare_digest` over UTF-8 bytes)
+  so a wrong token cannot be recovered by timing; the presented value is never
+  logged.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import structlog
+from fastapi import HTTPException, Request, status
+
+from meho_backplane.settings import get_settings
+
+__all__ = ["verify_metrics_access"]
+
+_log = structlog.get_logger(__name__)
+
+
+async def verify_metrics_access(request: Request) -> None:
+    """Enforce the opt-in bearer-token guard on ``/metrics`` and ``/ready``.
+
+    A no-op when ``metrics_auth_token`` is unset (default-open). Otherwise the
+    request must present ``Authorization: Bearer <token>`` matching the
+    configured token; a missing, malformed, or mismatched header raises ``401``
+    with a ``WWW-Authenticate: Bearer`` challenge.
+    """
+    token = get_settings().metrics_auth_token
+    if not token:
+        return
+    header = request.headers.get("authorization", "")
+    scheme, _, presented = header.partition(" ")
+    if (
+        scheme.lower() != "bearer"
+        or not presented
+        or not secrets.compare_digest(presented.encode("utf-8"), token.encode("utf-8"))
+    ):
+        _log.warning("metrics_access_denied", path=request.url.path)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="metrics_auth_required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1696,6 +1696,27 @@ class Settings(BaseModel):
     mail_smtp_password: str = Field(default="", repr=False)
     mail_from: str = Field(default="")
     mail_recipient_allowlist: str = Field(default="")
+    # #3499 — opt-in bearer-token guard for the operational exposition
+    # endpoints ``GET /metrics`` (:mod:`meho_backplane.main`) and
+    # ``GET /ready`` (:mod:`meho_backplane.health`). Both are served on the
+    # shared ingress and, unauthenticated, leak operational metrics and the
+    # effective four-eyes / feature-gate posture to anyone who can reach it.
+    # Empty ("", the default) leaves both endpoints **open** — behaviour is
+    # unchanged, so the in-cluster scraper and the kubelet readiness probe
+    # keep working with no config change. Set it to a shared secret to
+    # require ``Authorization: Bearer <token>`` on both endpoints
+    # (constant-time compared in :mod:`meho_backplane.metrics_access`); a
+    # deployment that turns it on must then hand the same token to the
+    # scraper (Prometheus ``bearer_token`` / ServiceMonitor
+    # ``bearerTokenSecret``) and to the readiness probe (``httpHeaders``).
+    # ``/healthz`` (pure liveness, no posture) is deliberately never guarded,
+    # so a bearer-less liveness path always exists. A **source-CIDR** allow
+    # was considered and rejected: behind the shared ingress the app sees the
+    # proxy's IP, not the real client's, so a peer-IP CIDR check cannot
+    # distinguish a booth visitor from the scraper without trusting a
+    # spoofable ``X-Forwarded-For``. ``repr=False`` keeps the token out of
+    # ``Settings`` reprs / structured logs.
+    metrics_auth_token: str = Field(default="", repr=False)
     # G11.3-T2 #823 / G0.19-T2 #1478 — autonomous-agent credential
     # sourcing for the scheduler. ``run_scheduled`` (G11.2-T2 #1096)
     # wants ``(client_id, client_secret)``; the scheduler resolves
@@ -2434,6 +2455,7 @@ def get_settings() -> Settings:
         mail_smtp_password=os.environ.get("MAIL_SMTP_PASSWORD", "").strip(),
         mail_from=os.environ.get("MAIL_FROM", "").strip(),
         mail_recipient_allowlist=os.environ.get("MAIL_RECIPIENT_ALLOWLIST", ""),
+        metrics_auth_token=os.environ.get("METRICS_AUTH_TOKEN", "").strip(),
         scheduler_agent_secret_env_pattern=os.environ.get(
             "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
             "MEHO_AGENT_SECRET_{tenant_id}_{client_id}",

--- a/backend/tests/test_api_v1_tenants_mail_recipient.py
+++ b/backend/tests/test_api_v1_tenants_mail_recipient.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the per-tenant mail-recipient policy route (#3499).
+
+Covers ``PATCH /api/v1/tenants/mail-recipient-policy``
+(:func:`meho_backplane.api.v1.tenants.update_mail_recipient_policy`):
+
+* Happy path: set a value, clear to inherit (``null``), set to deny (``""``);
+  the DB row and the resolved read-back reflect the write.
+* Null-vs-absent: an empty PATCH body leaves the column untouched.
+* Grammar validation: a malformed allowlist entry is a 422 at write time.
+* ``extra='forbid'``: an unknown key is a 422.
+* RBAC: ``operator`` / ``read_only`` -> 403 ``insufficient_role``;
+  ``tenant_admin`` -> 200.
+* Tenant isolation: a PATCH writes only the caller's own tenant.
+* Audit: an applied change writes one ``audit_log`` row; a no-op binds none.
+* Cache invalidation (the load-bearing one): a PATCH is reflected by the next
+  :func:`resolve_tenant_recipient_allowlist` **without** a cache reset or
+  restart -- proving the handler evicts the resolver's per-tenant cache.
+
+Drives the production ``meho_backplane.main:app`` so the real middleware chain
+(RequestContext -> Audit -> router) is exercised. DB is the autouse per-test
+SQLite + ``alembic upgrade head``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.mail.tenant_policy import (
+    reset_tenant_mail_policy_cache_for_testing,
+    resolve_tenant_recipient_allowlist,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Tenant
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._vault_fakes import install_fake_vault
+
+_ROUTE = "/api/v1/tenants/mail-recipient-policy"
+_TENANT_A = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires + isolate the resolver cache."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    reset_tenant_mail_policy_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    reset_tenant_mail_policy_cache_for_testing()
+
+
+def _token(
+    key: Any,
+    *,
+    sub: str = "op-admin",
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+    tenant_id: UUID = _TENANT_A,
+) -> str:
+    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(tenant_id))
+
+
+async def _seed_tenants(a_allowlist: str | None = None) -> None:
+    """Insert the two test tenants; tenant A carries the given mail-allowlist seed."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT_A))
+        ).scalar_one_or_none() is None:
+            session.add(
+                Tenant(
+                    id=_TENANT_A,
+                    slug="tenant-a",
+                    name="Tenant A",
+                    mail_recipient_allowlist=a_allowlist,
+                )
+            )
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT_B))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT_B, slug="tenant-b", name="Tenant B"))
+        await session.commit()
+
+
+async def _fetch_tenant(tenant_id: UUID) -> Tenant:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return (await session.execute(select(Tenant).where(Tenant.id == tenant_id))).scalar_one()
+
+
+async def _fetch_audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return list(
+            (await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))).scalars().all()
+        )
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    install_fake_vault(monkeypatch)
+    yield TestClient(app)
+
+
+def _patch(client: TestClient, token: str, body: dict[str, Any]) -> Any:
+    return client.patch(_ROUTE, json=body, headers={"Authorization": f"Bearer {token}"})
+
+
+# ---------------------------------------------------------------------------
+# Happy path: set / clear / deny
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_sets_allowlist_and_returns_resolved_policy(client: TestClient) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-set")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"mail_recipient_allowlist": "oncall@ops.test"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tenant_id"] == str(_TENANT_A)
+    assert body["mail_recipient_allowlist"] == "oncall@ops.test"
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.mail_recipient_allowlist == "oncall@ops.test"
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_string_is_deny(client: TestClient) -> None:
+    await _seed_tenants(a_allowlist="example.com")
+    key = make_rsa_keypair("kid-deny")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"mail_recipient_allowlist": ""})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mail_recipient_allowlist"] == ""
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.mail_recipient_allowlist == ""
+
+
+@pytest.mark.asyncio
+async def test_patch_null_clears_to_inherit(client: TestClient) -> None:
+    await _seed_tenants(a_allowlist="example.com")
+    key = make_rsa_keypair("kid-clear")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"mail_recipient_allowlist": None})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mail_recipient_allowlist"] is None
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.mail_recipient_allowlist is None
+
+
+@pytest.mark.asyncio
+async def test_empty_body_leaves_column_untouched(client: TestClient) -> None:
+    await _seed_tenants(a_allowlist="example.com")
+    key = make_rsa_keypair("kid-absent")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["mail_recipient_allowlist"] == "example.com"
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.mail_recipient_allowlist == "example.com"
+
+
+# ---------------------------------------------------------------------------
+# Validation: malformed grammar + unknown key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_allowlist_entry_is_422(client: TestClient) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-bad")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"mail_recipient_allowlist": "foo@"})
+    assert resp.status_code == 422, resp.text
+    tenant = await _fetch_tenant(_TENANT_A)
+    assert tenant.mail_recipient_allowlist is None  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_unknown_key_is_422(client: TestClient) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-extra")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"not_a_field": "x"})
+    assert resp.status_code == 422, resp.text
+
+
+# ---------------------------------------------------------------------------
+# RBAC + tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [TenantRole.OPERATOR, TenantRole.READ_ONLY])
+async def test_non_admin_forbidden(client: TestClient, role: TenantRole) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair(f"kid-{role.value}")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key, role=role), {"mail_recipient_allowlist": "a@b.com"})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_patch_writes_only_callers_tenant(client: TestClient) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-isolation")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"mail_recipient_allowlist": "a@b.com"})
+    assert resp.status_code == 200, resp.text
+    tenant_b = await _fetch_tenant(_TENANT_B)
+    assert tenant_b.mail_recipient_allowlist is None  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_applied_change_writes_audit_row(client: TestClient) -> None:
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-audit")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"mail_recipient_allowlist": "ops.test"})
+    assert resp.status_code == 200, resp.text
+    rows = await _fetch_audit_rows()
+    payload = rows[0].payload
+    assert payload["mail_recipient_policy_changed"] is True
+    assert payload["tenant_id"] == str(_TENANT_A)
+    assert payload["mail_recipient_allowlist_before"] == "inherit"
+    assert payload["mail_recipient_allowlist_after"] == "ops.test"
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation (load-bearing) — reflected without a cache reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_evicts_resolver_cache(client: TestClient) -> None:
+    await _seed_tenants()  # tenant A allowlist NULL -> inherit
+    # Prime the resolver cache with the pre-PATCH (inherit) value.
+    assert await resolve_tenant_recipient_allowlist(_TENANT_A) is None
+    key = make_rsa_keypair("kid-cache")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _patch(client, _token(key), {"mail_recipient_allowlist": "ops.test"})
+    assert resp.status_code == 200, resp.text
+    # No reset_...() call here — the route must have evicted the cache itself.
+    resolved = await resolve_tenant_recipient_allowlist(_TENANT_A)
+    assert resolved == (frozenset(), frozenset({"ops.test"}))

--- a/backend/tests/test_connectors_mail.py
+++ b/backend/tests/test_connectors_mail.py
@@ -63,10 +63,14 @@ from meho_backplane.connectors.mail.allowlist import (
     parse_recipient_allowlist,
 )
 from meho_backplane.connectors.mail.ops import register_mail_typed_operations
+from meho_backplane.connectors.mail.tenant_policy import (
+    reset_tenant_mail_policy_cache_for_testing,
+    resolve_tenant_recipient_allowlist,
+)
 from meho_backplane.connectors.mail.transport import MailSendResult, send_email
 from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AuditLog, EndpointDescriptor
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, Tenant
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations._lookup import parse_connector_id
 from meho_backplane.settings import get_settings
@@ -104,9 +108,11 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         monkeypatch.delenv(var, raising=False)
     get_settings.cache_clear()
     reset_dispatcher_caches()
+    reset_tenant_mail_policy_cache_for_testing()
     yield
     get_settings.cache_clear()
     reset_dispatcher_caches()
+    reset_tenant_mail_policy_cache_for_testing()
 
 
 def _configure_mail_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
@@ -995,3 +1001,198 @@ def test_parse_recipient_allowlist_accepts_the_documented_shapes(
 
     assert addresses == frozenset({"oncall@ops.test"})
     assert domains == frozenset({"example.com", "example.org", "corp.test"})
+
+
+# ---------------------------------------------------------------------------
+# Per-tenant recipient allowlist (#3499) — narrows on top of the instance floor
+# ---------------------------------------------------------------------------
+
+#: The operator ``_make_operator`` dispatches as; the seeded tenant row's id.
+_TENANT_ID = UUID(int=0)
+
+
+async def _seed_tenant_mail_allowlist(value: str | None) -> None:
+    """Insert the dispatch tenant row carrying *value* in ``mail_recipient_allowlist``.
+
+    ``value=None`` leaves the column NULL (inherit); ``""`` is deny; a string is
+    the tenant's own allowlist. The row id matches ``_make_operator``'s
+    ``tenant_id`` so the dispatch resolver reads exactly this policy.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Tenant(
+                id=_TENANT_ID,
+                slug="dispatch-tenant",
+                name="Dispatch Tenant",
+                mail_recipient_allowlist=value,
+            )
+        )
+        await session.commit()
+
+
+async def test_tenant_allowlist_unset_inherits_instance_floor(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type,
+    _registered_mail_op: None,
+) -> None:
+    """No tenant row (or NULL column) ⇒ inherit: the instance floor governs.
+
+    Instance allowlist admits ``example.com``; with no per-tenant override the
+    send goes through (sent=True), proving the tenant screen did not interpose.
+    """
+    _configure_mail_env(monkeypatch)  # instance MAIL_RECIPIENT_ALLOWLIST=example.com
+    # No _seed_tenant_mail_allowlist call -> the resolver sees no row -> inherit.
+
+    result = await _dispatch_send({"to": ["oncall@example.com"], "subject": "s", "body": "b"})
+
+    assert result.status == "ok", result.error
+    assert result.result["sent"] is True
+    assert result.result["reason"] is None
+
+
+async def test_tenant_empty_allowlist_denies_before_any_smtp_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+    _registered_mail_op: None,
+) -> None:
+    """An empty tenant allowlist denies every recipient before any connection.
+
+    The instance floor would admit ``oncall@example.com``, but the tenant's
+    empty allowlist refuses first — proving tenant-empty ⇒ deny, evaluated
+    ahead of the (exploding) transport.
+    """
+    _configure_mail_env(monkeypatch)
+    await _seed_tenant_mail_allowlist("")
+
+    result = await _dispatch_send({"to": ["oncall@example.com"], "subject": "s", "body": "b"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "sent": False,
+        "reason": "not_in_recipient_allowlist",
+        "to": ["oncall@example.com"],
+        "subject": "s",
+    }
+
+
+async def test_tenant_allowlist_narrows_within_the_instance_floor(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+    _registered_mail_op: None,
+) -> None:
+    """A tenant address-entry refuses another mailbox the instance domain admits.
+
+    Instance floor admits the whole ``example.com`` domain; the tenant narrows
+    to the single address ``oncall@example.com``. A send to
+    ``other@example.com`` is refused by the tenant screen even though the
+    instance floor would allow it — the narrowing is real and comes first.
+    """
+    _configure_mail_env(monkeypatch)  # instance = example.com (domain)
+    await _seed_tenant_mail_allowlist("oncall@example.com")
+
+    result = await _dispatch_send({"to": ["other@example.com"], "subject": "s", "body": "b"})
+
+    assert result.status == "ok", result.error
+    assert result.result["sent"] is False
+    assert result.result["reason"] == "not_in_recipient_allowlist"
+
+
+async def test_tenant_allowlist_admits_a_listed_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type,
+    _registered_mail_op: None,
+) -> None:
+    """A recipient in both the tenant allowlist and the instance floor sends."""
+    _configure_mail_env(monkeypatch)  # instance = example.com
+    await _seed_tenant_mail_allowlist("oncall@example.com")
+
+    result = await _dispatch_send({"to": ["oncall@example.com"], "subject": "s", "body": "b"})
+
+    assert result.status == "ok", result.error
+    assert result.result["sent"] is True
+    assert result.result["reason"] is None
+
+
+async def test_tenant_allowlist_cannot_widen_past_the_instance_floor(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+    _registered_mail_op: None,
+) -> None:
+    """A recipient the tenant lists but the instance floor does not is refused.
+
+    The tenant screen passes ``x@evil.test`` (it is in the tenant allowlist),
+    but the instance floor — applied by the transport afterwards — does not
+    list ``evil.test``, so the send is still refused. The tenant can only
+    narrow, never widen. (Exploding SMTP proves no connection opened.)
+    """
+    _configure_mail_env(monkeypatch)  # instance = example.com only
+    await _seed_tenant_mail_allowlist("evil.test")
+
+    result = await _dispatch_send({"to": ["x@evil.test"], "subject": "s", "body": "b"})
+
+    assert result.status == "ok", result.error
+    assert result.result["sent"] is False
+    assert result.result["reason"] == "not_in_recipient_allowlist"
+
+
+async def test_resolver_returns_none_for_unknown_tenant() -> None:
+    """An absent tenant row resolves to None (inherit), not deny."""
+    assert await resolve_tenant_recipient_allowlist(UUID(int=123)) is None
+
+
+async def test_resolver_parses_a_set_value() -> None:
+    """A non-null column parses to the ``(addresses, domains)`` tuple."""
+    await _seed_tenant_mail_allowlist("oncall@ops.test,example.com")
+    resolved = await resolve_tenant_recipient_allowlist(_TENANT_ID)
+    assert resolved == (frozenset({"oncall@ops.test"}), frozenset({"example.com"}))
+
+
+async def test_resolver_fails_closed_to_deny_on_read_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DB read error resolves to deny (empty allowlist), never to inherit."""
+
+    def _boom() -> None:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(
+        "meho_backplane.connectors.mail.tenant_policy.get_sessionmaker",
+        _boom,
+    )
+    resolved = await resolve_tenant_recipient_allowlist(UUID(int=7))
+    assert resolved == (frozenset(), frozenset())
+
+
+async def test_tenant_denied_send_writes_audit_row(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+    _registered_mail_op: None,
+) -> None:
+    """A tenant-denied ``mail.send`` is audited synchronously (sent=false).
+
+    The empty tenant allowlist refuses the send before any SMTP connection,
+    and the durable ``audit_log`` row records the refusal (``sent=false``,
+    ``reason=not_in_recipient_allowlist``) with recipients/subject and never
+    the body — the #3499 "denied delivery is audited" acceptance criterion.
+    """
+    _configure_mail_env(monkeypatch)
+    await _seed_tenant_mail_allowlist("")  # tenant deny
+
+    result = await _dispatch_send(
+        {"to": ["oncall@example.com"], "subject": "blocked", "body": "secret body"}
+    )
+    assert result.status == "ok", result.error
+    assert result.result["sent"] is False
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+    mail_rows = [r for r in rows if r.path == _OP_ID]
+    assert len(mail_rows) == 1
+    raw = mail_rows[0].raw_payload
+    assert raw is not None
+    assert raw["sent"] is False
+    assert raw["reason"] == "not_in_recipient_allowlist"
+    assert raw["to"] == ["oncall@example.com"]
+    assert "body" not in raw

--- a/backend/tests/test_db_models.py
+++ b/backend/tests/test_db_models.py
@@ -356,6 +356,7 @@ def test_migration_installs_tenant_table_and_indexes(
                 "flight_recorder_enabled",  # #3212 F1 per-tenant capture default
                 "flight_recorder_retention_days",  # #3212 F4 per-tenant retention
                 "flight_recorder_agent_readable",  # #3216 F5 per-tenant agent-read gate
+                "mail_recipient_allowlist",  # #3499 per-tenant mail recipient allowlist
             }
 
             audit_columns = {col["name"] for col in inspector.get_columns("audit_log")}

--- a/backend/tests/test_metrics_access.py
+++ b/backend/tests/test_metrics_access.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the opt-in ``/metrics`` + ``/ready`` bearer-token guard (#3499).
+
+Covers :mod:`meho_backplane.metrics_access` and its wiring onto the two
+exposition endpoints:
+
+* **Default-open** — with ``METRICS_AUTH_TOKEN`` unset, ``/metrics`` and
+  ``/ready`` are reachable unauthenticated exactly as before (no 401), so the
+  in-cluster scraper and kubelet readiness probe are undisturbed.
+* **Opt-in guard** — with the token set, ``/metrics`` and ``/ready`` refuse a
+  missing / malformed / mismatched bearer with 401 and admit the correct one.
+* **Liveness stays open** — ``/healthz`` is never guarded, so a bearer-less
+  liveness path always exists even when the guard is on.
+
+Drives the production ``meho_backplane.main:app`` (plain ``TestClient`` — no
+lifespan, so no readiness probes are registered; a guarded-and-authed
+``/ready`` therefore renders its own verdict, which is what we assert around,
+never the exact 200/503).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+_TOKEN = "s3cr3t-scrape-token"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the minimal Settings env; ``METRICS_AUTH_TOKEN`` starts unset."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.delenv("METRICS_AUTH_TOKEN", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(app)
+
+
+def _set_token(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("METRICS_AUTH_TOKEN", value)
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Default-open: behaviour unchanged when the guard is not configured
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_open_by_default(client: TestClient) -> None:
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert "http_requests_total" in resp.text or resp.text  # exposition rendered
+
+
+def test_ready_open_by_default(client: TestClient) -> None:
+    # No probes registered (no lifespan) -> 503, but crucially NOT 401.
+    resp = client.get("/ready")
+    assert resp.status_code != 401
+    assert "features" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Guard on: missing / malformed / wrong bearer -> 401
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_requires_bearer_when_token_set(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_token(monkeypatch, _TOKEN)
+    resp = client.get("/metrics")
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "metrics_auth_required"
+    assert resp.headers.get("www-authenticate") == "Bearer"
+
+
+def test_ready_requires_bearer_when_token_set(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_token(monkeypatch, _TOKEN)
+    resp = client.get("/ready")
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "metrics_auth_required"
+
+
+def test_wrong_bearer_denied(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_token(monkeypatch, _TOKEN)
+    resp = client.get("/metrics", headers={"Authorization": "Bearer not-the-token"})
+    assert resp.status_code == 401
+
+
+def test_non_bearer_scheme_denied(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_token(monkeypatch, _TOKEN)
+    resp = client.get("/metrics", headers={"Authorization": f"Basic {_TOKEN}"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Guard on: correct bearer admits; liveness always open
+# ---------------------------------------------------------------------------
+
+
+def test_correct_bearer_admits_metrics(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_token(monkeypatch, _TOKEN)
+    resp = client.get("/metrics", headers={"Authorization": f"Bearer {_TOKEN}"})
+    assert resp.status_code == 200
+
+
+def test_correct_bearer_admits_ready(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_token(monkeypatch, _TOKEN)
+    resp = client.get("/ready", headers={"Authorization": f"Bearer {_TOKEN}"})
+    # Admitted past the guard -> the readiness verdict renders (not a 401).
+    assert resp.status_code != 401
+    assert "features" in resp.json()
+
+
+def test_healthz_never_guarded(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_token(monkeypatch, _TOKEN)
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -46,8 +46,31 @@ from prometheus_client import REGISTRY
 
 from meho_backplane.main import app
 from meho_backplane.middleware import UNMATCHED_ROUTE_LABEL, RequestContextMiddleware
+from meho_backplane.settings import get_settings
 
 _UUID_HEX_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the minimal Settings env the exposition endpoints now need.
+
+    ``/metrics`` and ``/ready`` gained the opt-in bearer guard
+    :func:`~meho_backplane.metrics_access.verify_metrics_access` (#3499),
+    which calls :func:`get_settings` on every request. Without the required
+    Keycloak env vars ``get_settings`` raises ``KeyError`` before the
+    default-open short-circuit is reached, so this file — which drives both
+    endpoints against the bare production ``app`` — must pin them just like
+    every other test file does (see ``tests/conftest.py`` and
+    ``tests/test_metrics_access.py``). ``METRICS_AUTH_TOKEN`` stays unset so
+    the guard is default-open and behaviour is unchanged.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.delenv("METRICS_AUTH_TOKEN", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 def _configure_capture(buf: io.StringIO) -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -38,7 +38,7 @@
           "health"
         ],
         "summary": "Ready",
-        "description": "Readiness probe with deploy-time feature-gate visibility.\n\nReturns 200 with\n``{\"status\": \"ready\", \"checks\": [...], \"features\": {...}}`` when\nat least one probe is registered and every probe reports ``ok``.\nReturns 503 with\n``{\"status\": \"not_ready\", \"checks\": [...], \"features\": {...}}``\notherwise \u2014 including the fail-closed empty-registry case at the\nchassis stage. The empty case is handled explicitly because\n``all([])`` is vacuously ``True`` in Python, which would otherwise\nflip the chassis to \"ready\" with zero evidence.\n\nThe ``features`` block (G0.14-T7 #1148) enumerates the four gated\nfeatures and their configured-vs-missing-env state. It is emitted\non **both** branches \u2014 the operator's \"is this deploy correctly\nwired?\" question is independent of the probe-registry verdict.\nSee :func:`meho_backplane.features.build_features_block` for the\nblock's shape and the audit table in\n``docs/codebase/error-message-shape.md`` for why this surface\nexists (signals 16, 17).",
+        "description": "Readiness probe with deploy-time feature-gate visibility.\n\nGuarded by :func:`~meho_backplane.metrics_access.verify_metrics_access`\n(#3499): open by default, but when ``METRICS_AUTH_TOKEN`` is set the\ncaller must present a matching bearer token or the request is refused\n401 \u2014 so the ``features`` block's four-eyes / feature-gate posture is\nnot readable unauthenticated on a shared ingress. ``/healthz`` (pure\nliveness) is deliberately left unguarded, so a bearer-less liveness path\nalways exists; a deployment that turns the guard on carries the token on\nthe readiness probe via ``httpHeaders``.\n\nReturns 200 with\n``{\"status\": \"ready\", \"checks\": [...], \"features\": {...}}`` when\nat least one probe is registered and every probe reports ``ok``.\nReturns 503 with\n``{\"status\": \"not_ready\", \"checks\": [...], \"features\": {...}}``\notherwise \u2014 including the fail-closed empty-registry case at the\nchassis stage. The empty case is handled explicitly because\n``all([])`` is vacuously ``True`` in Python, which would otherwise\nflip the chassis to \"ready\" with zero evidence.\n\nThe ``features`` block (G0.14-T7 #1148) enumerates the four gated\nfeatures and their configured-vs-missing-env state. It is emitted\non **both** branches \u2014 the operator's \"is this deploy correctly\nwired?\" question is independent of the probe-registry verdict.\nSee :func:`meho_backplane.features.build_features_block` for the\nblock's shape and the audit table in\n``docs/codebase/error-message-shape.md`` for why this surface\nexists (signals 16, 17).",
         "operationId": "ready_ready_get",
         "responses": {
           "200": {
@@ -1398,6 +1398,60 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TenantFlightRecorderPolicy"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tenants/mail-recipient-policy": {
+      "patch": {
+        "tags": [
+          "tenants"
+        ],
+        "summary": "Update Mail Recipient Policy",
+        "description": "Set or clear the caller's per-tenant mail-recipient allowlist (#3499).\n\nTenant-scoped to ``operator.tenant_id`` (no cross-tenant write is\nexpressible -- no tenant id is accepted in the path or body).\n``tenant_admin`` only. Applies the field only when present in the body; an\napplied change is folded into this request's ``audit_log`` row (field / old\n/ new, ``None`` -> ``inherit`` sentinel) and evicts the resolver's\nper-tenant cache so the new value governs the next dispatched ``mail.send``\nwithout a restart.",
+        "operationId": "update_mail_recipient_policy_api_v1_tenants_mail_recipient_policy_patch",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantMailRecipientPolicyUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantMailRecipientPolicy"
                 }
               }
             }
@@ -21218,7 +21272,7 @@
     "/metrics": {
       "get": {
         "summary": "Metrics",
-        "description": "Prometheus exposition endpoint.\n\nReturns the default registry contents (process / GC collectors +\nthe ``http_requests_total`` counter the middleware increments) in\nthe legacy ``text/plain; version=0.0.4`` format that every\nPrometheus scraper understands.",
+        "description": "Prometheus exposition endpoint.\n\nReturns the default registry contents (process / GC collectors +\nthe ``http_requests_total`` counter the middleware increments) in\nthe legacy ``text/plain; version=0.0.4`` format that every\nPrometheus scraper understands.\n\nGuarded by :func:`~meho_backplane.metrics_access.verify_metrics_access`\n(#3499): open by default, but when ``METRICS_AUTH_TOKEN`` is set the\ncaller must present a matching bearer token or the request is refused\n401 before any registry content is rendered.",
         "operationId": "metrics_metrics_get",
         "responses": {
           "200": {
@@ -33311,6 +33365,40 @@
         "type": "object",
         "title": "TenantFlightRecorderPolicyUpdate",
         "description": "``PATCH /api/v1/tenants/flight-recorder-policy`` body.\n\nAll three fields are optional-partial: only fields the client actually\nsends are applied (``model_dump(exclude_unset=True)`` in the handler keys\noff ``model_fields_set``, so a JSON ``null`` is distinguished from an\nabsent key). ``extra='forbid'`` rejects unknown keys with a 422.\n\n* ``flight_recorder_enabled`` (F1) -- Boolean, ``NOT NULL`` at the DB\n  layer. Absent = leave unchanged; ``true`` / ``false`` flips the\n  per-tenant capture default. An explicit ``null`` is rejected (the column\n  has no inherit state) -- the validator fires only when the key is\n  present, so an absent field never trips it.\n* ``flight_recorder_agent_readable`` (F5) -- **tri-state**. Absent = leave\n  unchanged; ``true`` / ``false`` force the agent-read override on / off;\n  ``null`` clears it back to inherit (follow the capture default). This is\n  the JSON-``null``-vs-absent distinction the tri-state needs.\n* ``flight_recorder_retention_days`` (F4) -- nullable, bounded ``1..365``\n  (the reaper window; matches ``Settings.flight_recorder_retention_days_default``'s\n  ``ge=1, le=365``). Absent = leave unchanged; an int sets the per-tenant\n  window; ``null`` clears it back to the global default. The bound applies\n  only to the int arm -- a ``null`` clear is always legal."
+      },
+      "TenantMailRecipientPolicy": {
+        "properties": {
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "mail_recipient_allowlist": {
+            "type": "string",
+            "nullable": true,
+            "title": "Mail Recipient Allowlist"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tenant_id",
+          "mail_recipient_allowlist"
+        ],
+        "title": "TenantMailRecipientPolicy",
+        "description": "Resolved per-tenant mail-recipient policy -- the PATCH read-back shape (#3499).\n\nFrozen; maps 1:1 to the tenant's ``mail_recipient_allowlist`` column plus the\ntenant id. ``mail_recipient_allowlist`` is nullable: ``None`` means\n**inherit** (no per-tenant narrowing; the deployment-level\n``MAIL_RECIPIENT_ALLOWLIST`` instance floor alone governs the send), ``\"\"``\nmeans **deny** (an empty tenant allowlist refuses every dispatched\n``mail.send``), and a comma-separated string is the tenant's own recipient\nspace (still intersected with the instance floor at the transport)."
+      },
+      "TenantMailRecipientPolicyUpdate": {
+        "properties": {
+          "mail_recipient_allowlist": {
+            "type": "string",
+            "nullable": true,
+            "title": "Mail Recipient Allowlist"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "TenantMailRecipientPolicyUpdate",
+        "description": "``PATCH /api/v1/tenants/mail-recipient-policy`` body (#3499).\n\nThe single field is optional-partial (``model_dump(exclude_unset=True)`` in\nthe handler keys off ``model_fields_set``, so a JSON ``null`` is\ndistinguished from an absent key). ``extra='forbid'`` rejects unknown keys\nwith a 422.\n\n* absent = leave the column unchanged.\n* ``null`` = clear back to **inherit** (the instance floor alone governs the\n  tenant's ``mail.send``).\n* ``\"\"`` = **deny** (an empty tenant allowlist refuses every dispatched\n  send) -- the shared-instance containment lever.\n* a comma-separated address/domain string = the tenant's own recipient\n  space. Validated with the same grammar as the instance floor\n  (:func:`~meho_backplane.connectors.mail.allowlist.parse_recipient_allowlist`),\n  so a malformed entry (whitespace, ``foo@``, bare ``@``, ...) is a 422 at\n  write time rather than a silent inert allowlist at dispatch time."
       },
       "TenantRole": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -8380,6 +8380,41 @@ type TenantFlightRecorderPolicyUpdate struct {
 	FlightRecorderRetentionDays *int  `json:"flight_recorder_retention_days"`
 }
 
+// TenantMailRecipientPolicy Resolved per-tenant mail-recipient policy -- the PATCH read-back shape (#3499).
+//
+// Frozen; maps 1:1 to the tenant's “mail_recipient_allowlist“ column plus the
+// tenant id. “mail_recipient_allowlist“ is nullable: “None“ means
+// **inherit** (no per-tenant narrowing; the deployment-level
+// “MAIL_RECIPIENT_ALLOWLIST“ instance floor alone governs the send), “""“
+// means **deny** (an empty tenant allowlist refuses every dispatched
+// “mail.send“), and a comma-separated string is the tenant's own recipient
+// space (still intersected with the instance floor at the transport).
+type TenantMailRecipientPolicy struct {
+	MailRecipientAllowlist *string            `json:"mail_recipient_allowlist"`
+	TenantId               openapi_types.UUID `json:"tenant_id"`
+}
+
+// TenantMailRecipientPolicyUpdate “PATCH /api/v1/tenants/mail-recipient-policy“ body (#3499).
+//
+// The single field is optional-partial (“model_dump(exclude_unset=True)“ in
+// the handler keys off “model_fields_set“, so a JSON “null“ is
+// distinguished from an absent key). “extra='forbid'“ rejects unknown keys
+// with a 422.
+//
+//   - absent = leave the column unchanged.
+//   - “null“ = clear back to **inherit** (the instance floor alone governs the
+//     tenant's “mail.send“).
+//   - “""“ = **deny** (an empty tenant allowlist refuses every dispatched
+//     send) -- the shared-instance containment lever.
+//   - a comma-separated address/domain string = the tenant's own recipient
+//     space. Validated with the same grammar as the instance floor
+//     (:func:`~meho_backplane.connectors.mail.allowlist.parse_recipient_allowlist`),
+//     so a malformed entry (whitespace, “foo@“, bare “@“, ...) is a 422 at
+//     write time rather than a silent inert allowlist at dispatch time.
+type TenantMailRecipientPolicyUpdate struct {
+	MailRecipientAllowlist *string `json:"mail_recipient_allowlist"`
+}
+
 // TenantRole Per-tenant role granted to the operator by the JWT issuer.
 //
 // The set is intentionally small in v0.2: a closed three-value enum
@@ -10036,6 +10071,11 @@ type UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams struc
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams defines parameters for UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatch.
+type UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // DependenciesApiV1TopologyDependenciesNameGetParams defines parameters for DependenciesApiV1TopologyDependenciesNameGet.
 type DependenciesApiV1TopologyDependenciesNameGetParams struct {
 	Depth      *int    `form:"depth,omitempty" json:"depth,omitempty"`
@@ -10657,6 +10697,9 @@ type UpdateTargetApiV1TargetsNamePatchJSONRequestBody = TargetUpdate
 
 // UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody defines body for UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch for application/json ContentType.
 type UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody = TenantFlightRecorderPolicyUpdate
+
+// UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchJSONRequestBody defines body for UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatch for application/json ContentType.
+type UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchJSONRequestBody = TenantMailRecipientPolicyUpdate
 
 // AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody defines body for AnnotateEdgeRouteApiV1TopologyEdgesPost for application/json ContentType.
 type AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody = UnderscoreAnnotateEdgeRequest
@@ -12854,6 +12897,11 @@ type ClientInterface interface {
 	UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithBody(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBody request with any body
+	UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBody(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatch(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, body UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DependenciesApiV1TopologyDependenciesNameGet request
 	DependenciesApiV1TopologyDependenciesNameGet(ctx context.Context, name string, params *DependenciesApiV1TopologyDependenciesNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -16256,6 +16304,30 @@ func (c *Client) UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch
 
 func (c *Client) UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatch(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBody(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatch(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, body UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -30308,6 +30380,61 @@ func NewUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRequestWi
 	return req, nil
 }
 
+// NewUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchRequest calls the generic UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatch builder with application/json body
+func NewUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchRequest(server string, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, body UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchRequestWithBody generates requests for UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatch with any type of body
+func NewUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchRequestWithBody(server string, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/tenants/mail-recipient-policy")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewDependenciesApiV1TopologyDependenciesNameGetRequest generates requests for DependenciesApiV1TopologyDependenciesNameGet
 func NewDependenciesApiV1TopologyDependenciesNameGetRequest(server string, name string, params *DependenciesApiV1TopologyDependenciesNameGetParams) (*http.Request, error) {
 	var err error
@@ -42555,6 +42682,11 @@ type ClientWithResponsesInterface interface {
 
 	UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchWithResponse(ctx context.Context, params *UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchParams, body UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse, error)
 
+	// UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBodyWithResponse request with any body
+	UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBodyWithResponse(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse, error)
+
+	UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithResponse(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, body UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse, error)
+
 	// DependenciesApiV1TopologyDependenciesNameGetWithResponse request
 	DependenciesApiV1TopologyDependenciesNameGetWithResponse(ctx context.Context, name string, params *DependenciesApiV1TopologyDependenciesNameGetParams, reqEditors ...RequestEditorFn) (*DependenciesApiV1TopologyDependenciesNameGetResponse, error)
 
@@ -46977,6 +47109,29 @@ func (r UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse)
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TenantMailRecipientPolicy
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -53789,6 +53944,23 @@ func (c *ClientWithResponses) UpdateFlightRecorderPolicyApiV1TenantsFlightRecord
 		return nil, err
 	}
 	return ParseUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchResponse(rsp)
+}
+
+// UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBodyWithResponse request with arbitrary body returning *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse
+func (c *ClientWithResponses) UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBodyWithResponse(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse, error) {
+	rsp, err := c.UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithResponse(ctx context.Context, params *UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams, body UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse, error) {
+	rsp, err := c.UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatch(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse(rsp)
 }
 
 // DependenciesApiV1TopologyDependenciesNameGetWithResponse request returning *DependenciesApiV1TopologyDependenciesNameGetResponse
@@ -61699,6 +61871,39 @@ func ParseUpdateFlightRecorderPolicyApiV1TenantsFlightRecorderPolicyPatchRespons
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest TenantFlightRecorderPolicy
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse parses an HTTP response from a UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithResponse call
+func ParseUpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse(rsp *http.Response) (*UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TenantMailRecipientPolicy
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/tenants/mail_recipient.go
+++ b/cli/internal/cmd/tenants/mail_recipient.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package tenants
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newMailRecipientPolicyCmd returns `meho tenants mail-recipient-policy`.
+func newMailRecipientPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "mail-recipient-policy",
+		Short:        "Manage the tenant's mail-recipient allowlist (tenant_admin)",
+		Long:         "Read/write the operator's own tenant mail-recipient allowlist (#3499).",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newMailSetCmd())
+	return cmd
+}
+
+type mailSetOptions struct {
+	allowlist         string
+	allowlistSet      bool
+	clear             bool
+	jsonOut           bool
+	backplaneOverride string
+}
+
+// newMailSetCmd returns `meho tenants mail-recipient-policy set`.
+//
+//	meho tenants mail-recipient-policy set
+//	  --allowlist "oncall@ops.test,alerts.example.com"  # the tenant's own recipient space
+//	  --allowlist ""                                     # deny (no mail for this tenant)
+//	  --clear                                            # clear back to inherit the instance floor
+//	  [--json] [--backplane <url>]
+//
+// Tenant-scoped (the caller's own tenant, from the JWT). tenant_admin only.
+// The tenant allowlist NARROWS on top of the deployment-level
+// MAIL_RECIPIENT_ALLOWLIST instance floor: it can restrict a tenant to no mail
+// (or a smaller recipient set) but never widen past the floor, which the
+// backplane still applies at send time. Pass exactly one of --allowlist /
+// --clear.
+//
+// Exit codes: 0 ok; 2 auth_expired; 3 unreachable; 4 unexpected (incl. 422 /
+// 404); 5 insufficient_role.
+func newMailSetCmd() *cobra.Command {
+	var opts mailSetOptions
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set or clear the tenant mail-recipient allowlist (tenant_admin)",
+		Long: "set PATCHes /api/v1/tenants/mail-recipient-policy for the operator's own " +
+			"tenant. tenant_admin only — operator / read_only land as 403 insufficient_role.\n\n" +
+			"--allowlist sets the tenant's recipient space (comma-separated full addresses " +
+			"and/or domains); an empty --allowlist=\"\" denies all mail for the tenant. " +
+			"--clear removes the per-tenant override so the tenant inherits the deployment " +
+			"MAIL_RECIPIENT_ALLOWLIST instance floor. The tenant allowlist only narrows: the " +
+			"instance floor is still applied at send time, so a tenant can never widen past " +
+			"it. Pass exactly one of --allowlist / --clear.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts.allowlistSet = cmd.Flags().Changed("allowlist")
+			return runMailSet(cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.allowlist, "allowlist", "",
+		"the tenant's permitted recipient space (comma-separated addresses/domains); "+
+			"empty string denies all mail for the tenant")
+	cmd.Flags().BoolVar(&opts.clear, "clear", false,
+		"clear the per-tenant override back to inheriting the instance floor")
+	cmd.Flags().BoolVar(&opts.jsonOut, "json", false,
+		"emit the resolved policy as JSON instead of the human summary")
+	cmd.Flags().StringVar(&opts.backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+// buildMailBody assembles the sparse PATCH body from the flags the operator
+// set. A nil map value marshals to JSON null (an explicit clear-to-inherit); a
+// present string (including "") sets the tenant allowlist verbatim.
+func buildMailBody(opts mailSetOptions) (map[string]any, error) {
+	if opts.allowlistSet && opts.clear {
+		return nil, fmt.Errorf("--allowlist and --clear are mutually exclusive")
+	}
+	body := map[string]any{}
+	switch {
+	case opts.allowlistSet:
+		body["mail_recipient_allowlist"] = opts.allowlist
+	case opts.clear:
+		body["mail_recipient_allowlist"] = nil // explicit null -> inherit
+	default:
+		return nil, fmt.Errorf("nothing to change; pass --allowlist <value> or --clear")
+	}
+	return body, nil
+}
+
+func runMailSet(cmd *cobra.Command, opts mailSetOptions) error {
+	body, err := buildMailBody(opts)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.jsonOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.jsonOut)
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("encode request body: %v", err)), opts.jsonOut)
+	}
+	resp, err := patchMailPolicy(cmd.Context(), backplaneURL, payload)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.jsonOut)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.jsonOut)
+	}
+	var policy api.TenantMailRecipientPolicy
+	if err := json.Unmarshal(resp.Body, &policy); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode policy response: %v", err)), opts.jsonOut)
+	}
+	if opts.jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), policy)
+	}
+	printMailPolicySummary(cmd.OutOrStdout(), &policy)
+	return nil
+}
+
+func patchMailPolicy(ctx context.Context, backplaneURL string, payload []byte) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return doRequest(ctx, authed, func(ctx context.Context) (*http.Response, error) {
+		return authed.UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchWithBody(
+			ctx,
+			&api.UpdateMailRecipientPolicyApiV1TenantsMailRecipientPolicyPatchParams{},
+			"application/json",
+			bytes.NewReader(payload),
+		)
+	})
+}
+
+// printMailPolicySummary renders the resolved policy as a compact confirmation.
+// A NULL renders "inherit"; an empty string renders "deny" so the operator sees
+// the tri-state resolution, not an ambiguous blank.
+func printMailPolicySummary(w io.Writer, p *api.TenantMailRecipientPolicy) {
+	if p == nil {
+		return
+	}
+	allow := "inherit (instance floor)"
+	if p.MailRecipientAllowlist != nil {
+		if *p.MailRecipientAllowlist == "" {
+			allow = "deny (empty — no mail for this tenant)"
+		} else {
+			allow = *p.MailRecipientAllowlist
+		}
+	}
+	fmt.Fprintln(w, "updated mail-recipient policy")
+	fmt.Fprintf(w, "%-12s %s\n", "tenant_id:", p.TenantId.String())
+	fmt.Fprintf(w, "%-12s %s\n", "allowlist:", allow)
+}

--- a/cli/internal/cmd/tenants/tenants.go
+++ b/cli/internal/cmd/tenants/tenants.go
@@ -4,14 +4,19 @@
 // Package tenants hosts the cobra commands under `meho tenants ...` for the
 // operator-plane per-tenant policy surface (#3272).
 //
-// v0.2 ships one policy family — the flight-recorder capture policy:
+// Two policy families ship here, each tenant-scoped (the caller's own tenant,
+// from the JWT — no tenant id is accepted, so there is no cross-tenant write)
+// and tenant_admin only (operator / read_only land as 403 insufficient_role):
 //
 //   - `meho tenants flight-recorder-policy set [--enabled] [--agent-readable]
 //     [--retention-days N | --clear-retention]` — PATCH
-//     /api/v1/tenants/flight-recorder-policy. Tenant-scoped (the caller's own
-//     tenant, from the JWT — no tenant id is accepted, so there is no
-//     cross-tenant write). tenant_admin only; operator / read_only land as 403
-//     insufficient_role.
+//     /api/v1/tenants/flight-recorder-policy.
+//   - `meho tenants mail-recipient-policy set [--allowlist <value> | --clear]`
+//     — PATCH /api/v1/tenants/mail-recipient-policy (#3499). The tenant
+//     allowlist narrows the deployment-level MAIL_RECIPIENT_ALLOWLIST instance
+//     floor: an empty `--allowlist=""` denies all mail for the tenant, a value
+//     restricts it, `--clear` inherits the floor. It can never widen past the
+//     floor, which the backplane still applies at send time.
 //
 // The verb builds a **sparse** JSON body (only the fields the operator set)
 // rather than the generated `TenantFlightRecorderPolicyUpdate` struct: that
@@ -47,12 +52,14 @@ import (
 // top-level meho command tree by cmd/root.go.
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "tenants",
-		Short:        "Operate per-tenant policy (flight-recorder capture policy)",
-		Long:         "Manage the operator's own tenant policy. v0.2 ships the flight-recorder capture policy.",
+		Use:   "tenants",
+		Short: "Operate per-tenant policy (flight-recorder capture, mail-recipient allowlist)",
+		Long: "Manage the operator's own tenant policy — the flight-recorder capture policy " +
+			"and the mail-recipient allowlist.",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newFlightRecorderPolicyCmd())
+	cmd.AddCommand(newMailRecipientPolicyCmd())
 	return cmd
 }
 

--- a/docs-site/reference/cli.md
+++ b/docs-site/reference/cli.md
@@ -4153,7 +4153,7 @@ meho targets probe <name-or-alias> [flags]
 
 ## `meho tenants`
 
-Operate per-tenant policy (flight-recorder capture policy)
+Operate per-tenant policy (flight-recorder capture, mail-recipient allowlist)
 
 ```
 meho tenants
@@ -4181,6 +4181,27 @@ meho tenants flight-recorder-policy set [flags]
 - `--enabled` — per-tenant capture default (F1); send true or false
 - `--json` — emit the resolved policy as JSON instead of the human summary
 - `--retention-days` — per-tenant trace retention window in days (F4; 1..365)
+
+### `meho tenants mail-recipient-policy`
+
+Manage the tenant's mail-recipient allowlist (tenant_admin)
+
+```
+meho tenants mail-recipient-policy
+```
+
+#### `meho tenants mail-recipient-policy set`
+
+Set or clear the tenant mail-recipient allowlist (tenant_admin)
+
+```
+meho tenants mail-recipient-policy set [flags]
+```
+
+- `--allowlist` — the tenant's permitted recipient space (comma-separated addresses/domains); empty string denies all mail for the tenant
+- `--backplane` — backplane URL (defaults to the URL recorded by the most recent `meho login`)
+- `--clear` — clear the per-tenant override back to inheriting the instance floor
+- `--json` — emit the resolved policy as JSON instead of the human summary
 
 ## `meho topology`
 

--- a/docs/codebase/connectors-mail.md
+++ b/docs/codebase/connectors-mail.md
@@ -167,6 +167,55 @@ non-empty, so a typo that had disabled every send reported as an
 ordinary "not listed" refusal instead of the "connector is inert"
 diagnostic.
 
+## Per-tenant recipient allowlist (#3499)
+
+`MAIL_RECIPIENT_ALLOWLIST` is deployment-level (one MTA, one floor). On a
+**shared** instance that single floor cannot be narrowed per tenant, so an
+approved `mail.send` in one tenant could deliver to the recipients another
+tenant configured — the Envision-stand threat (meho-internal#320): an untrusted
+visitor tenant's approved send reaching real evoila mailboxes / a live Teams
+channel. #3499 adds a **per-tenant narrowing** override on top of the instance
+floor.
+
+**Where it lives.** `tenant.mail_recipient_allowlist` (nullable `Text`,
+migration `0101`) resolved per dispatch by
+`connectors/mail/tenant_policy.py::resolve_tenant_recipient_allowlist` (a
+60s-TTL cache mirroring the flight-recorder resolver). Tri-state on the value:
+
+| column | meaning |
+|---|---|
+| `NULL` (default) | **inherit** — no per-tenant screen; the instance floor alone governs |
+| `""` (empty) | **deny** — the tenant's parsed allowlist is empty, so every dispatched `mail.send` for the tenant is refused |
+| `"a@b.com,example.com"` | the tenant's own recipient space, still intersected with the instance floor |
+
+**Where it is evaluated.** In the **dispatch handler** `ops.mail_send`, *before*
+`transport.send_email`. Each recipient is screened against the tenant's parsed
+set with the shared `allowlist.recipient_allowed` matcher; one refused recipient
+returns `{sent: false, reason: "not_in_recipient_allowlist"}` (the same product
+the instance floor uses, so the dispatch stays `status="ok"` and the denial is
+audited synchronously through the normal path). The transport then applies the
+instance floor as always — so the tenant screen can only **narrow**, never widen
+past the deployment floor.
+
+**Dispatch-only.** The screen is on the `call_operation` / CLI dispatch path,
+which carries an `operator` (hence a `tenant_id`). The checks notifier's
+direct-import `transport.send_email` call (#2719) is **not** tenant-dispatched —
+it has no operator — so it keeps only the instance floor, unchanged. This is
+deliberate: the notifier is a deployment-internal alert path, not an
+agent/operator-initiated send that a tenant boundary should narrow.
+
+**Fail-closed.** Unlike the flight-recorder resolver (fail-open, "capture less
+on doubt"), this resolver fails **closed** — a DB read/parse error resolves to
+deny (empty allowlist), never to inherit. Falling through to the instance floor
+on a read error would defeat the containment the override exists to provide;
+this is a delivery-authorization decision, so doubt reduces exposure. The deny
+is not cached, so a transient error does not pin the tenant to deny for the TTL.
+
+**Operator surface.** Set/clear the override through
+`PATCH /api/v1/tenants/mail-recipient-policy` (tenant_admin) or
+`meho tenants mail-recipient-policy set --allowlist … | --clear`. Full write-path
+detail: [`tenant-mail-policy.md`](tenant-mail-policy.md).
+
 ## Safety posture
 
 `safety_level="caution"` + `requires_approval=False`: human/service
@@ -192,9 +241,11 @@ events carry host/port/reason only, never the password or body.
 - The SMTP session timeout is a module constant
   (`transport._SMTP_TIMEOUT_SECONDS`, 30 s), not a settings knob — no
   consumer has asked to tune it (#1177 substrate minimalism).
-- No HTML, attachments, templating, or per-tenant SMTP — explicitly out
-  of scope for #2717; further transports (Slack/PagerDuty/webhook) are
-  new connectors when a consumer asks.
+- No HTML, attachments, templating, or per-tenant **SMTP block** —
+  explicitly out of scope for #2717; further transports
+  (Slack/PagerDuty/webhook) are new connectors when a consumer asks. (A
+  per-tenant **recipient allowlist** did ship in #3499 — see the section
+  above; that narrows *who* a tenant may mail, not *which MTA* it uses.)
 
 ## References
 

--- a/docs/codebase/metrics-ready-access.md
+++ b/docs/codebase/metrics-ready-access.md
@@ -1,0 +1,58 @@
+# `/metrics` and `/ready` access guard
+
+## Overview
+
+The backplane serves two operational exposition endpoints that are **not**
+behind the JWT auth chain:
+
+- `GET /metrics` (`meho_backplane/main.py`) — the Prometheus exposition
+  (process/GC collectors + `http_requests_total`).
+- `GET /ready` (`meho_backplane/health.py`) — the readiness verdict plus a
+  `features` block that enumerates the four gated features and, indirectly, the
+  effective four-eyes / feature-gate posture of the deploy.
+
+On a shared ingress, unauthenticated, both leak production operational state to
+anyone who can reach the ingress — at a customer-facing event (meho-internal#320)
+that is production activity readable at the public booth. #3499 adds an
+**opt-in** guard so a deployment can require auth on both endpoints, with
+**behaviour unchanged by default**.
+
+## The guard
+
+`meho_backplane/metrics_access.py::verify_metrics_access` is a FastAPI
+dependency both routes declare (`dependencies=[Depends(verify_metrics_access)]`).
+
+- **Default-open.** When `Settings.metrics_auth_token` (`METRICS_AUTH_TOKEN`) is
+  empty — the default — the dependency returns immediately. The in-cluster
+  Prometheus scraper (the chart's `ServiceMonitor`) and the kubelet readiness
+  probe keep working with no config change.
+- **Opt-in bearer.** When the token is set, both endpoints require
+  `Authorization: Bearer <token>`; a missing / malformed / mismatched header is
+  refused `401 metrics_auth_required` with a `WWW-Authenticate: Bearer`
+  challenge, **before** any registry content or readiness verdict is rendered.
+  The compare is constant-time (`secrets.compare_digest` over UTF-8 bytes) and
+  the presented value is never logged.
+
+## Why bearer, not source-CIDR
+
+The interim event mitigation was an ingress-level CIDR block. The durable
+in-app fix is a **bearer token**, not a peer-IP CIDR check: behind the shared
+ingress the app sees the ingress controller's IP, not the real client's, so a
+peer-IP allowlist cannot distinguish a booth visitor from the scraper without
+trusting a spoofable `X-Forwarded-For`. A bearer token is proxy-independent and
+is the standard Prometheus scrape auth (`bearer_token` / ServiceMonitor
+`bearerTokenSecret`); a kubelet probe carries it via `httpHeaders`.
+
+## `/healthz` is never guarded
+
+`GET /healthz` (liveness) is a pure process-up signal (always 200,
+`{"status": "ok"}`, no posture) and is deliberately left unguarded, so a
+bearer-less liveness path always exists even with the guard on. A deployment
+that enables the guard must then hand the token to the scraper and carry it on
+the **readiness** probe's `httpHeaders`; liveness needs no change.
+
+## Tests
+
+`backend/tests/test_metrics_access.py` — default-open (`/metrics`, `/ready`
+reachable, no 401), guard-on 401s (missing / wrong / non-bearer), guard-on
+admit with the correct bearer, and `/healthz` always 200.

--- a/docs/codebase/tenant-mail-policy.md
+++ b/docs/codebase/tenant-mail-policy.md
@@ -1,0 +1,97 @@
+# Per-tenant mail-recipient policy — operator mutation surface
+
+## Overview
+
+The `mail.*` connector's recipient floor (`MAIL_RECIPIENT_ALLOWLIST`,
+`connectors/mail/allowlist.py`) is deployment-level: one MTA, one allowlist for
+the whole instance. On a **shared** instance that single floor cannot be
+narrowed per tenant, so an approved `mail.send` in one tenant could deliver to
+the recipients another tenant configured (the Envision-stand threat,
+meho-internal#320). #3499 adds a **per-tenant narrowing** override —
+`tenant.mail_recipient_allowlist` — and this surface is its operator-plane write
+path.
+
+It is an **operator-plane** surface: REST + CLI only, gated at the
+`tenant_admin` tier. It is deliberately **not** on the 25-tool agent working
+surface and has **no MCP tool** — narrowing a tenant's mail reach is a
+governance decision, an operator action, not an agent one. (Simplest correct
+answer per postulate 5: REST + CLI, no MCP tool at all — the same posture as the
+flight-recorder policy, [`flight-recorder-policy.md`](flight-recorder-policy.md).)
+
+## Route
+
+- `PATCH /api/v1/tenants/mail-recipient-policy`
+  (`meho_backplane/api/v1/tenants.py`) — the single
+  `mail_recipient_allowlist` field. **Tenant-scoped to the caller's own tenant**
+  (`operator.tenant_id` from the JWT); it accepts no tenant id in the path or
+  body, so a cross-tenant write is not expressible.
+  `require_role(TenantRole.TENANT_ADMIN)` (`operator` / `read_only` → 403).
+  Body `TenantMailRecipientPolicyUpdate` (optional-partial, `extra='forbid'`);
+  returns the resolved `TenantMailRecipientPolicy`.
+
+## Tri-state on the value (not a Boolean)
+
+Unlike the flight-recorder tri-states (Boolean columns), the mail allowlist
+carries its tri-state on a nullable `Text` value:
+
+- **absent** (key omitted) = leave the column unchanged.
+- `null` = clear back to **inherit** — no per-tenant screen; the deployment
+  `MAIL_RECIPIENT_ALLOWLIST` instance floor alone governs the tenant's
+  `mail.send`.
+- `""` (empty string) = **deny** — the tenant's parsed allowlist is empty, so
+  every dispatched `mail.send` for the tenant is refused (the inverted
+  "empty ⇒ inert" default the instance floor already uses). This is the
+  shared-instance containment lever: pin an untrusted-visitor tenant to no mail
+  while production keeps its alert mail.
+- a comma-separated address/domain string = the tenant's own recipient space,
+  validated at write time with the same grammar as the instance floor
+  (`parse_recipient_allowlist`), so a malformed entry (`foo@`, bare `@`,
+  whitespace, …) is a **422 now** rather than a silently-inert allowlist at
+  dispatch time.
+
+The handler keys off `model_fields_set` (`model_dump(exclude_unset=True)`), so
+the JSON-`null`-vs-absent distinction is preserved (same discipline as the
+flight-recorder route).
+
+## Resolution + narrowing (where it takes effect)
+
+`connectors/mail/tenant_policy.py::resolve_tenant_recipient_allowlist` reads the
+column per dispatch (60s-TTL cache) and the `mail.send` handler
+(`connectors/mail/ops.py`) screens every recipient against the tenant's parsed
+set **before** the transport applies the instance floor. The tenant screen can
+only **narrow**: a recipient the tenant lists but the instance floor does not is
+still refused by the transport. The checks notifier's direct-import
+`send_email` path is not tenant-dispatched and keeps only the instance floor.
+
+**Fail-closed:** a DB read/parse error in the resolver resolves to deny (empty
+allowlist), never to inherit — a delivery-authorization decision where doubt
+reduces exposure (the opposite direction from the flight-recorder resolver's
+fail-open). The deny is not cached.
+
+## Audit
+
+An applied change is folded into the request's `audit_log` row via `audit_*`
+contextvars naming field / old / new (governance-relevant, never silent). A
+`NULL` value is bound as the `inherit` sentinel because the audit-payload
+builder drops `None` contextvars (mirroring the flight-recorder route and the
+target CA-pin `""` marker); an empty-string deny is bound verbatim. A no-op /
+absent field binds nothing.
+
+## Cache invalidation
+
+The resolver caches per-tenant policy for 60s. The route calls
+`invalidate_tenant_mail_policy_cache` on a change so the new value governs the
+**next dispatched `mail.send`** rather than waiting out the TTL or a restart
+(proven by the without-reset test in `test_api_v1_tenants_mail_recipient.py`).
+
+## CLI
+
+- `meho tenants mail-recipient-policy set --allowlist <value>` — set the
+  tenant's recipient space (comma-separated addresses/domains); `--allowlist=""`
+  denies all mail for the tenant.
+- `meho tenants mail-recipient-policy set --clear` — clear the override back to
+  inheriting the instance floor.
+  (`cli/internal/cmd/tenants/mail_recipient.go`.) The verb builds a **sparse**
+  PATCH body (only the field the operator set) so a nil never marshals to an
+  unintended `null`, preserving the null-vs-absent distinction — same rationale
+  as the flight-recorder verb.


### PR DESCRIPTION
## Summary

Durable backplane fixes for the two instance-wide safety settings the Envision shared-instance isolation review (meho-internal#320) found could not be narrowed per tenant.

- **Per-tenant mail-recipient allowlist.** A narrowing override on top of the deployment-level `MAIL_RECIPIENT_ALLOWLIST` instance floor. New nullable `tenant.mail_recipient_allowlist` column (migration `0101`), resolved per dispatch (fail-closed, 60s cache) and screened in the `mail.send` handler **before** the transport's instance floor. `NULL` = inherit, `""` = deny, a value = the tenant's own recipient space — always intersected with the instance floor, so the screen can only **narrow**, never widen. An untrusted-visitor tenant can be pinned to no mail while production keeps its alert mail. The checks notifier's direct-import `send_email` path is **not** tenant-dispatched and keeps only the instance floor. Denied sends are audited synchronously (`sent=false`).
- **Opt-in `/metrics` + `/ready` auth.** New `METRICS_AUTH_TOKEN` bearer guard on both endpoints; **default empty = unchanged**, so the in-cluster scraper and kubelet probes are undisturbed. `/healthz` (pure liveness) is never guarded. Bearer, not source-CIDR — behind the shared ingress the app sees the proxy IP, not the real client's.
- **Operator surface (no MCP tool):** `tenant_admin` `PATCH /api/v1/tenants/mail-recipient-policy` + `meho tenants mail-recipient-policy set --allowlist … | --clear`.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean on all changed files.
- [x] `mypy` — clean on changed modules.
- [x] `code-quality.py --diff` — 0 blockers (5 warnings are pre-existing legacy debt in touched files).
- [x] `pytest tests/test_connectors_mail.py` — 66 passed, incl. tenant precedence (unset→instance / set→tenant / empty→deny), narrowing, no-widen, fail-closed resolver, and a tenant-denied-send-is-audited case (AC3).
- [x] `pytest tests/test_api_v1_tenants_mail_recipient.py` — 11 passed (set/clear/deny, null-vs-absent, malformed→422, RBAC, tenant isolation, audit row, cache invalidation without restart).
- [x] `pytest tests/test_metrics_access.py` — 9 passed (default-open, guard-on 401 for missing/wrong/non-bearer, admit correct bearer, `/healthz` always open).
- [x] `pytest tests/migrations/` — 433 passed (0101 up/down + rollback matrix).
- [x] `pytest tests/test_api_v1_tenants_flight_recorder.py tests/test_middleware.py tests/test_features.py tests/test_mcp_surface_conformance.py tests/test_citation_links.py` — 185 passed (no regression; no new MCP tool).
- [x] `cd cli && make snapshot-openapi && make generate && make cli-docs` — committed; `go build` + `go test ./internal/cmd/tenants/...` green.

### Acceptance criteria
- [x] A tenant can be configured with an empty mail-recipient allowlist (no `mail.*` delivery) while another keeps delivery, on the same instance — per-tenant resolver + `test_patch_writes_only_callers_tenant` + empty→deny / unset→inherit tests.
- [x] `/metrics` and `/ready` are not readable by an unauthenticated caller when the guard is opted in; in-cluster liveness (`/healthz`) / readiness probes are not broken (opt-in, default unchanged; readiness carries the token via `httpHeaders`).
- [x] Denied mail delivery is audited — `test_tenant_denied_send_writes_audit_row`.

## Out of scope
- `APPROVAL_ALLOW_SELF_APPROVAL` stays a single global posture flag (meho-internal#320 explicitly keeps it out of scope).
- Per-tenant **SMTP block** (which MTA) remains out of scope (#2717); this narrows *who* a tenant may mail, not *which MTA*.

## Adjacent findings (not addressed)
- `code-quality.py` warns on pre-existing size of `health.py` (569 lines) and function length of `update_flight_recorder_policy` / `build_openapi_schema` — untouched legacy debt.

## Changelog

`Added` — Per-tenant mail-recipient allowlist (`tenant.mail_recipient_allowlist`, `PATCH /api/v1/tenants/mail-recipient-policy`, `meho tenants mail-recipient-policy set`) that narrows the instance `MAIL_RECIPIENT_ALLOWLIST` floor per tenant, and an opt-in `METRICS_AUTH_TOKEN` bearer guard for `/metrics` and `/ready` (default unchanged; `/healthz` never guarded). (#3499)

Closes #3499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
