### PR TITLE
feat(dispatch): per-principal / per-tenant MCP dispatch rate limits (#3500)

### DIFF
--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -104,6 +104,10 @@ from meho_backplane.mcp.schemas import (
     JsonRpcResponse,
     ServerCapabilities,
 )
+from meho_backplane.mcp.session_limit import (
+    check_mcp_session_cap,
+    resolve_mcp_session_cap,
+)
 from meho_backplane.settings import Settings, get_settings
 from meho_backplane.version import deployed_version_label
 
@@ -394,6 +398,36 @@ async def _session_instructions(operator: Operator) -> str | None:
     return joined or None
 
 
+async def _enforce_mcp_session_cap(operator: Operator) -> None:
+    """Refuse ``initialize`` when the tenant is over its session cap (#3500).
+
+    MEHO holds no session store, so the cap bounds new-session handshakes
+    per window (see :mod:`meho_backplane.mcp.session_limit`). Disabled by
+    default (cap ``0``) -- an unconfigured tenant makes no Valkey call.
+    Over the cap, raises :class:`McpRateLimitedError` (JSON-RPC ``-32000``)
+    carrying a ``retry_after_seconds`` hint so the client backs off.
+    """
+    cap = resolve_mcp_session_cap(get_settings(), operator.tenant_id)
+    retry_after = await check_mcp_session_cap(operator.tenant_id, cap)
+    if retry_after is None:
+        return
+    _log.warning(
+        "mcp_session_cap_exceeded",
+        tenant_id=str(operator.tenant_id),
+        cap=cap,
+        retry_after_seconds=retry_after,
+    )
+    raise McpRateLimitedError(
+        f"session cap exceeded: {cap} new MCP sessions per minute for this "
+        f"tenant; retry after {retry_after}s",
+        data={
+            "limit": cap,
+            "window_seconds": 60,
+            "retry_after_seconds": retry_after,
+        },
+    )
+
+
 async def _initialize(
     operator: Operator,
     params: dict[str, Any] | None,
@@ -415,7 +449,13 @@ async def _initialize(
     WARNING, while the response body stays unchanged. Multi-version
     negotiation behaviour is tracked as explicit follow-up work,
     gated on concrete operator demand.
+
+    #3500: a per-tenant session cap is enforced first, so a tenant over its
+    new-sessions-per-minute limit is refused with a ``-32000`` rate-limited
+    error before a new session is negotiated.
     """
+    await _enforce_mcp_session_cap(operator)
+
     # ``params or {}`` deliberately collapses ``None`` and ``{}``. Spec-
     # aligned: a missing ``params`` field on the JSON-RPC request and an
     # explicit empty params object are both equivalent to "no required

--- a/backend/src/meho_backplane/mcp/session_limit.py
+++ b/backend/src/meho_backplane/mcp/session_limit.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tenant cap on new MCP sessions per window (#3500).
+
+MEHO holds **no stateful MCP session store** -- a session id is issued
+on ``initialize`` purely for audit correlation and then forgotten
+(``mcp/server.py`` ``_issue_mcp_session_id``). A precise "concurrent
+sessions" count is therefore unknowable without building a session
+registry, which the finding (meho-internal#321) explicitly did not ask
+for. The cheap, deterministic backstop that MEHO *can* enforce is a cap
+on how many new session handshakes a tenant may start per window: every
+``initialize` is one new session, so bounding ``initialize`` volume per
+tenant bounds session creation -- the abuse vector at the stand (a
+visitor tab-spamming reconnects, a client relaunch loop).
+
+Same fixed-window ``INCR`` + ``EXPIRE`` shape as the dispatch and
+announce limiters, keyed per tenant. A cap of ``0`` (the default)
+disables it with no Valkey round-trip, so existing tenants are
+unaffected until an operator opts in.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Final
+from uuid import UUID
+
+from prometheus_client import Counter
+
+from meho_backplane.broadcast.client import get_broadcast_client
+from meho_backplane.operations.dispatch_limits import resolve_int_override
+from meho_backplane.settings import Settings
+
+__all__ = [
+    "MCP_SESSION_LIMITED_TOTAL",
+    "MCP_SESSION_LIMIT_WINDOW_SECONDS",
+    "check_mcp_session_cap",
+    "resolve_mcp_session_cap",
+]
+
+#: Fixed window width, matching the ``*_per_minute`` cap unit.
+MCP_SESSION_LIMIT_WINDOW_SECONDS: Final[int] = 60
+
+#: MCP ``initialize`` handshakes rejected by the per-tenant session cap.
+MCP_SESSION_LIMITED_TOTAL: Counter = Counter(
+    "mcp_session_limited_total",
+    "MCP initialize handshakes rejected by the per-tenant session cap (#3500).",
+)
+
+
+def resolve_mcp_session_cap(settings: Settings, tenant_id: UUID) -> int:
+    """New-sessions-per-window cap for *tenant_id* (0 = disabled)."""
+    return resolve_int_override(
+        settings.mcp_session_start_limit_per_minute_overrides,
+        tenant_id,
+        settings.mcp_session_start_limit_per_minute,
+    )
+
+
+def _session_window_key(tenant_id: UUID, bucket: int) -> str:
+    """Per-``(tenant, window)`` session-start counter key."""
+    return f"meho:ratelimit:mcpsession:{tenant_id}:{bucket}"
+
+
+async def check_mcp_session_cap(tenant_id: UUID, cap: int) -> int | None:
+    """Increment the window counter; return a retry-after when over *cap*.
+
+    A *cap* of ``0`` (or negative) disables the check with no Valkey
+    round-trip. Otherwise increments the current window's per-tenant
+    session-start counter; when the count exceeds *cap* returns the
+    whole seconds until the window rolls over, else ``None``.
+
+    Cross-tenant isolation is structural (the key is derived from the
+    JWT-bound ``tenant_id``).
+
+    Raises:
+        Exception: Any redis-py / Valkey failure propagates verbatim
+            (fail-loud, consistent with the dispatch + announce limiters).
+    """
+    if cap <= 0:
+        return None
+
+    window = MCP_SESSION_LIMIT_WINDOW_SECONDS
+    now = int(time.time())
+    bucket = now // window
+    key = _session_window_key(tenant_id, bucket)
+
+    client = get_broadcast_client()
+    async with client.pipeline(transaction=True) as pipe:
+        pipe.incr(key)
+        pipe.expire(key, window)
+        count, _ = await pipe.execute()
+
+    if count > cap:
+        MCP_SESSION_LIMITED_TOTAL.inc()
+        return window - (now % window)
+    return None

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -52,6 +52,7 @@ __all__ = [
     "agent_run_audit_meta_var",
     "agent_session_id_var",
     "audit_and_broadcast_safe",
+    "audit_rejection_safe",
     "parent_audit_id_var",
     "policy_decision_var",
     "publish_broadcast",
@@ -810,6 +811,50 @@ async def audit_and_broadcast_safe(
     except Exception:
         _log.exception(
             "dispatch_broadcast_failed",
+            op_id=descriptor.op_id,
+            result_status=result_status,
+            operator_sub=operator.sub,
+        )
+
+
+async def audit_rejection_safe(
+    *,
+    audit_id: uuid.UUID,
+    operator: Operator,
+    descriptor: EndpointDescriptor,
+    target: Any,
+    params_hash: str,
+    result_status: str,
+    duration_ms: float,
+) -> None:
+    """Write one audit row for a pre-execution rejection; no broadcast (#3500).
+
+    Used for the abuse-control rejections (rate limit / concurrent-op cap):
+    the over-limit event must be audited (spec §6), but -- unlike a policy
+    denial, which is a rare governance event worth broadcasting -- it must
+    NOT publish a broadcast. Under a flood every rejection would otherwise
+    emit one ``XADD`` into the tenant's coordination feed, amplifying the
+    very load the limiter exists to shed and spamming the feed.
+
+    The row is written **fail-open**: an audit-insert failure is logged, not
+    raised, so a Valkey/DB wobble cannot turn a cheap rejection into a 500.
+    The request changed nothing, so a missing audit row for a rejected call
+    is a monitoring gap, not a correctness one -- the opposite of the
+    write-class success path's fail-closed ``require_audit`` contract.
+    """
+    try:
+        await write_audit_row(
+            audit_id=audit_id,
+            operator=operator,
+            descriptor=descriptor,
+            target=target,
+            params_hash=params_hash,
+            result_status=result_status,
+            duration_ms=duration_ms,
+        )
+    except Exception:
+        _log.exception(
+            "dispatch_rejection_audit_failed",
             op_id=descriptor.op_id,
             result_status=result_status,
             operator_sub=operator.sub,

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -65,6 +65,7 @@ __all__ = [
     "result_invalid_params",
     "result_no_connector",
     "result_no_target",
+    "result_rate_limited",
     "result_target_invalid_type",
     "result_target_required",
     "result_unknown_op",
@@ -460,6 +461,47 @@ def result_denied(op_id: str, reason: str, duration_ms: float) -> OperationResul
         error=f"denied: {reason}",
         duration_ms=duration_ms,
         extras={"error_code": "denied", "reason": reason},
+    )
+
+
+def result_rate_limited(
+    op_id: str,
+    *,
+    kind: str,
+    limit: int,
+    retry_after_seconds: int,
+    duration_ms: float,
+) -> OperationResult:
+    """Dispatch rejected by a per-principal / per-tenant limit (#3500).
+
+    Returned before the op executes when the caller is over its
+    per-minute dispatch rate limit (``kind='rate'``) or its concurrent-op
+    cap (``kind='concurrency'``). No vendor traffic occurs; the rejection
+    is audited synchronously with ``result_status='rate_limited'``.
+
+    The structured envelope carries ``retry_after_seconds`` so an agent
+    can back off intelligently, and ``status_code_for_result`` maps the
+    status to a synthetic ``429`` on the audit row. The status is a
+    distinct ``rate_limited`` (not ``denied``/``error``) so consumers and
+    the audit ledger can tell an abuse-control rejection from a policy
+    denial or a connector error.
+    """
+    if kind == "rate":
+        reason = f"rate limit exceeded: {limit} dispatches per minute for this principal"
+    else:
+        reason = f"concurrent-op cap exceeded: {limit} in-flight dispatches for this principal"
+    return OperationResult(
+        status="rate_limited",
+        op_id=op_id,
+        error=f"rate_limited: {reason}; retry after {retry_after_seconds}s",
+        duration_ms=duration_ms,
+        extras={
+            "error_code": "rate_limited",
+            "kind": kind,
+            "limit": limit,
+            "retry_after_seconds": retry_after_seconds,
+            "reason": reason,
+        },
     )
 
 
@@ -1865,7 +1907,8 @@ def status_code_for_result(result_status: str) -> int:
     ``already_resumed`` -- the exactly-one-resumer no-op #2293, a benign
     "executed elsewhere", not a failure), ``202`` for awaiting approval /
     pending (accepted but not yet executed — the agent needs-approval
-    path), ``403`` for denied, ``500`` for error. The synthetic values
+    path), ``403`` for denied, ``429`` for rate_limited (over a
+    per-principal dispatch limit, #3500), ``500`` for error. The synthetic values
     are not surfaced to operators; the canonical signal lives in
     ``payload["result_status"]`` on the audit row.
     """
@@ -1877,6 +1920,8 @@ def status_code_for_result(result_status: str) -> int:
         return 202
     if result_status == "denied":
         return 403
+    if result_status == "rate_limited":
+        return 429
     if result_status == "pending":
         return 202
     return 500

--- a/backend/src/meho_backplane/operations/dispatch_limits.py
+++ b/backend/src/meho_backplane/operations/dispatch_limits.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-principal / per-tenant dispatch rate limit + concurrent-op cap (#3500).
+
+MEHO's only pre-existing rate limits are the event-ingest webhook
+(``events/ingest/rate_limit.py``) and the agent broadcast-announce
+(``broadcast/rate_limit.py``); ``identity_budget`` caps only MEHO's own
+internal agent-run LLM spend. Nothing bounded a client's
+``call_operation`` / ``search_operations`` request volume, so one
+visitor -- or a runaway agent loop -- on a shared instance could exhaust
+DB / connector pools and, via triggered internal agent runs, the
+server-side LLM budget, degrading every tenant. This module is the
+server-side backstop the finding (meho-internal#321) asked for.
+
+Two controls, both enforced on the shared dispatch path so CLI, MCP and
+the REST dispatch route are covered by one seam (they all funnel through
+:func:`meho_backplane.operations.dispatcher.dispatch`):
+
+* **Rate limit** -- a per-``(tenant, principal)`` fixed-window request
+  cap. A burst above the per-minute cap is rejected with a
+  ``retry_after`` hint. This reuses the ``INCR`` + ``EXPIRE`` shape the
+  two existing limiters already proved on the shared Valkey; a
+  token-bucket refinement was considered and rejected for v1 -- the
+  fixed-window counter is atomic on a single ``INCR`` (no Lua / no
+  read-modify-write race), matches the codebase's two other limiters,
+  and satisfies the "a burst is throttled" acceptance criterion.
+
+* **Concurrent-op cap** -- a per-``(tenant, principal)`` count of
+  in-flight top-level dispatches. Acquired before an op executes,
+  released when it finishes. A safety ``EXPIRE`` bounds how long a
+  slot leaked by a crashed worker survives before it self-heals.
+
+Per-tenant configuration
+========================
+
+Every limit is a global default plus a per-tenant override, expressed
+purely in settings -- no migration, mirroring the
+``agent_runs_disabled_tenants`` precedent. The override string is a CSV
+of ``<tenant-uuid>=<int>`` pairs; a tenant absent from the override map
+falls back to the global default. **A limit of ``0`` (the default for
+every knob) disables that control entirely** -- no Valkey round-trip --
+so existing tenants are unaffected until an operator opts in. The lab
+enables tight caps for the untrusted-visitor tenant only.
+
+Fail-loud on a Valkey outage
+============================
+
+Any redis-py / Valkey failure propagates verbatim, consistent with the
+two existing limiters. Making the check fail-open would let a principal
+bypass the cap during a Valkey wobble -- defeating an abuse control --
+so the safe posture is to fail the dispatch closed (the dispatcher's
+surrounding ``try`` converts it into a structured ``connector_error``).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Final
+from uuid import UUID
+
+import structlog
+from prometheus_client import Counter
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast.client import get_broadcast_client
+from meho_backplane.settings import Settings, get_settings
+
+__all__ = [
+    "DISPATCH_CONCURRENCY_LIMITED_TOTAL",
+    "DISPATCH_CONCURRENCY_RETRY_AFTER_SECONDS",
+    "DISPATCH_RATE_LIMITED_TOTAL",
+    "DISPATCH_RATE_LIMIT_WINDOW_SECONDS",
+    "acquire_dispatch_slot",
+    "check_dispatch_rate_limit",
+    "rate_limited_read_envelope",
+    "release_dispatch_slot",
+    "resolve_dispatch_concurrency_cap",
+    "resolve_dispatch_rate_limit",
+    "resolve_int_override",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Fixed window width. One minute, matching the ``*_per_minute`` cap unit
+#: the two existing limiters use.
+DISPATCH_RATE_LIMIT_WINDOW_SECONDS: Final[int] = 60
+
+#: Retry-after hint (seconds) returned when the concurrency cap is hit.
+#: A concurrent-op rejection has no window to roll over -- the caller
+#: should retry once an in-flight op of its own finishes, which is
+#: typically sub-second, so a small fixed hint is the honest signal.
+DISPATCH_CONCURRENCY_RETRY_AFTER_SECONDS: Final[int] = 1
+
+#: Dispatches rejected by the per-principal rate limit. Unlabelled
+#: (coarse-cardinality posture, same as the broadcast limiter's
+#: counter): a sustained nonzero rate is the operational signal; the
+#: per-tenant / per-principal attribution lives on the ``rate_limited``
+#: audit rows the dispatcher writes, not in a high-cardinality label.
+DISPATCH_RATE_LIMITED_TOTAL: Counter = Counter(
+    "dispatch_rate_limited_total",
+    "Dispatches rejected by the per-principal rate limit (#3500).",
+)
+
+#: Dispatches rejected by the per-principal concurrent-op cap.
+DISPATCH_CONCURRENCY_LIMITED_TOTAL: Counter = Counter(
+    "dispatch_concurrency_limited_total",
+    "Dispatches rejected by the per-principal concurrent-op cap (#3500).",
+)
+
+
+def resolve_int_override(overrides_csv: str, tenant_id: UUID, default: int) -> int:
+    """Resolve a per-tenant integer override, falling back to *default*.
+
+    *overrides_csv* is a comma-separated list of ``<tenant-uuid>=<int>``
+    pairs (case-insensitive UUID, whitespace ignored), mirroring the
+    ``agent_runs_disabled_tenants`` CSV shape but carrying a value per
+    tenant. The first entry whose UUID matches *tenant_id* wins; a
+    malformed entry (bad UUID, non-integer value, missing ``=``) is
+    skipped with a warning so one typo cannot silently drop every
+    override. When no entry matches, the global *default* applies.
+    """
+    if not overrides_csv:
+        return default
+    for raw in overrides_csv.split(","):
+        entry = raw.strip()
+        if not entry:
+            continue
+        key, sep, value = entry.partition("=")
+        if not sep:
+            _log.warning("dispatch_limit_override_malformed", entry=entry, reason="no '='")
+            continue
+        try:
+            entry_tenant = UUID(key.strip())
+        except ValueError:
+            _log.warning("dispatch_limit_override_malformed", entry=entry, reason="bad uuid")
+            continue
+        try:
+            entry_value = int(value.strip())
+        except ValueError:
+            _log.warning("dispatch_limit_override_malformed", entry=entry, reason="bad int")
+            continue
+        if entry_tenant == tenant_id:
+            return entry_value
+    return default
+
+
+def resolve_dispatch_rate_limit(settings: Settings, tenant_id: UUID) -> int:
+    """Per-minute dispatch rate limit for *tenant_id* (0 = disabled)."""
+    return resolve_int_override(
+        settings.dispatch_rate_limit_per_minute_overrides,
+        tenant_id,
+        settings.dispatch_rate_limit_per_minute,
+    )
+
+
+def resolve_dispatch_concurrency_cap(settings: Settings, tenant_id: UUID) -> int:
+    """Per-principal concurrent-op cap for *tenant_id* (0 = disabled)."""
+    return resolve_int_override(
+        settings.dispatch_max_concurrent_ops_overrides,
+        tenant_id,
+        settings.dispatch_max_concurrent_ops,
+    )
+
+
+def _rate_window_key(tenant_id: UUID, principal_sub: str, bucket: int) -> str:
+    """Per-``(tenant, principal, window)`` rate-counter key.
+
+    The bucket (``floor(now / window)``) is embedded so each window gets
+    its own key: a new window starts from zero and the ``EXPIRE`` on the
+    old key reclaims it. The ``dispatch`` segment keeps this namespace
+    clear of the ``announce`` / ``ingest`` limiter keys.
+    """
+    return f"meho:ratelimit:dispatch:{tenant_id}:{principal_sub}:{bucket}"
+
+
+def _concurrency_key(tenant_id: UUID, principal_sub: str) -> str:
+    """Per-``(tenant, principal)`` in-flight-dispatch counter key."""
+    return f"meho:concurrency:dispatch:{tenant_id}:{principal_sub}"
+
+
+async def rate_limited_read_envelope(operator: Operator) -> dict[str, Any] | None:
+    """Rate-limit a read-path meta-tool; return an envelope when over limit.
+
+    The read-path meta-tools (``search_operations`` / ``preview_operation``
+    / ``result_query``) return a plain ``dict`` envelope rather than an
+    :class:`OperationResult`, and do no vendor traffic. They share the same
+    per-principal dispatch rate budget as ``call_operation`` (one bucket per
+    principal bounds a caller's total request volume across the working
+    surface). Returns ``None`` when the caller is under its limit (or the
+    limit is disabled); otherwise a structured ``rate_limited`` envelope
+    carrying ``retry_after_seconds`` for the caller to back off on.
+    """
+    settings = get_settings()
+    limit = resolve_dispatch_rate_limit(settings, operator.tenant_id)
+    retry_after = await check_dispatch_rate_limit(operator.tenant_id, operator.sub, limit)
+    if retry_after is None:
+        return None
+    return {
+        "status": "rate_limited",
+        "error_code": "rate_limited",
+        "kind": "rate",
+        "limit": limit,
+        "retry_after_seconds": retry_after,
+        "error": (
+            f"rate_limited: {limit} dispatches per minute for this principal; "
+            f"retry after {retry_after}s"
+        ),
+    }
+
+
+async def check_dispatch_rate_limit(
+    tenant_id: UUID,
+    principal_sub: str,
+    limit: int,
+) -> int | None:
+    """Increment the window counter; return a retry-after when over *limit*.
+
+    A *limit* of ``0`` (or negative) disables the check with no Valkey
+    round-trip. Otherwise increments the current window's per-principal
+    counter; when the count exceeds *limit* returns the whole seconds
+    until the window rolls over (the caller surfaces it as the
+    ``retry_after_seconds`` on a rate-limited result), else ``None``.
+
+    The counter is per ``(tenant_id, principal_sub, window)``, so one
+    principal hitting its cap never affects another principal in the
+    same tenant, and cross-tenant isolation is structural (the key is
+    derived from the JWT-bound ``tenant_id``).
+
+    Raises:
+        Exception: Any redis-py / Valkey failure propagates verbatim
+            (fail-loud, consistent with the two existing limiters).
+    """
+    if limit <= 0:
+        return None
+
+    window = DISPATCH_RATE_LIMIT_WINDOW_SECONDS
+    now = int(time.time())
+    bucket = now // window
+    key = _rate_window_key(tenant_id, principal_sub, bucket)
+
+    client = get_broadcast_client()
+    # INCR + EXPIRE atomically so a counter can never outlive its window:
+    # the EXPIRE re-arms on every call within the window, extending the
+    # key's life to at most one window past its last write -- harmless,
+    # since the next window uses a different key.
+    async with client.pipeline(transaction=True) as pipe:
+        pipe.incr(key)
+        pipe.expire(key, window)
+        count, _ = await pipe.execute()
+
+    if count > limit:
+        DISPATCH_RATE_LIMITED_TOTAL.inc()
+        return window - (now % window)
+    return None
+
+
+async def acquire_dispatch_slot(
+    tenant_id: UUID,
+    principal_sub: str,
+    cap: int,
+    ttl_seconds: int,
+) -> tuple[int | None, str | None]:
+    """Try to take one in-flight-dispatch slot for this principal.
+
+    A *cap* of ``0`` (or negative) disables the check with no Valkey
+    round-trip and returns ``(None, None)`` -- nothing to release.
+
+    Otherwise increments the per-principal in-flight counter (arming a
+    safety *ttl_seconds* ``EXPIRE`` so a slot leaked by a crashed worker
+    self-heals). When the resulting count exceeds *cap* the increment is
+    rolled back immediately and ``(retry_after, None)`` is returned --
+    the caller rejects the dispatch without holding a slot. On success
+    returns ``(None, key)``; the caller **must** pass *key* to
+    :func:`release_dispatch_slot` in a ``finally`` once the op finishes.
+
+    Raises:
+        Exception: Any redis-py / Valkey failure propagates verbatim.
+    """
+    if cap <= 0:
+        return None, None
+
+    key = _concurrency_key(tenant_id, principal_sub)
+    client = get_broadcast_client()
+    async with client.pipeline(transaction=True) as pipe:
+        pipe.incr(key)
+        pipe.expire(key, ttl_seconds)
+        count, _ = await pipe.execute()
+
+    if count > cap:
+        # Roll back our own increment so a rejected attempt does not
+        # permanently consume a slot. Use the same self-healing DECR the
+        # release path uses (deletes the key at zero) so a burst of
+        # rejections cannot drive the counter negative.
+        await _decr_and_reap(key)
+        DISPATCH_CONCURRENCY_LIMITED_TOTAL.inc()
+        return DISPATCH_CONCURRENCY_RETRY_AFTER_SECONDS, None
+    return None, key
+
+
+async def release_dispatch_slot(key: str | None) -> None:
+    """Release a slot taken by :func:`acquire_dispatch_slot`.
+
+    ``None`` (the disabled / not-acquired case) is a no-op. Any Valkey
+    failure propagates verbatim; the dispatcher runs this in its
+    ``finally`` where an exception would already be in flight.
+    """
+    if key is None:
+        return
+    await _decr_and_reap(key)
+
+
+async def _decr_and_reap(key: str) -> None:
+    """DECR the counter, deleting it once it reaches zero.
+
+    Deleting at zero keeps the counter non-negative and self-healing:
+    a release that races an expired window's reset cannot drive the key
+    below zero (which would silently widen the effective cap).
+    """
+    client = get_broadcast_client()
+    remaining = await client.decr(key)
+    if remaining <= 0:
+        await client.delete(key)

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -269,6 +269,7 @@ from meho_backplane.flight_recorder import capture as flight_recorder_capture
 from meho_backplane.operations._audit import (
     AuditCommitError,
     audit_and_broadcast_safe,
+    audit_rejection_safe,
     parent_audit_id_var,
     policy_decision_var,
     reveal_secret_var,
@@ -2466,12 +2467,11 @@ async def dispatch(
         _rate_retry = await check_dispatch_rate_limit(operator.tenant_id, operator.sub, _rate_limit)
         if _rate_retry is not None:
             duration_ms = _elapsed_ms(started)
-            await audit_and_broadcast_safe(
+            await audit_rejection_safe(
                 audit_id=uuid.uuid4(),
                 operator=operator,
                 descriptor=descriptor,
                 target=target,
-                params=params,
                 params_hash=params_hash,
                 result_status="rate_limited",
                 duration_ms=duration_ms,
@@ -2492,12 +2492,11 @@ async def dispatch(
         )
         if _conc_retry is not None:
             duration_ms = _elapsed_ms(started)
-            await audit_and_broadcast_safe(
+            await audit_rejection_safe(
                 audit_id=uuid.uuid4(),
                 operator=operator,
                 descriptor=descriptor,
                 target=target,
-                params=params,
                 params_hash=params_hash,
                 result_status="rate_limited",
                 duration_ms=duration_ms,

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -301,6 +301,7 @@ from meho_backplane.operations._errors import (
     result_no_connector,
     result_preview_binding_required,
     result_preview_hash_mismatch,
+    result_rate_limited,
     result_target_required,
     result_unknown_op,
     wrap_ok_result,
@@ -337,9 +338,18 @@ from meho_backplane.operations._validate import (
     validate_params,
 )
 from meho_backplane.operations.composite import (
+    COMPOSITE_DEPTH_TOP_LEVEL,
     CompositeRecursionLimitExceeded,
     DispatchChild,
+    composite_depth_var,
     get_dispatch_child,
+)
+from meho_backplane.operations.dispatch_limits import (
+    acquire_dispatch_slot,
+    check_dispatch_rate_limit,
+    release_dispatch_slot,
+    resolve_dispatch_concurrency_cap,
+    resolve_dispatch_rate_limit,
 )
 from meho_backplane.operations.reducer import (
     PassThroughReducer,
@@ -350,6 +360,7 @@ from meho_backplane.redaction import (
     apply_connector_boundary_redaction,
     manifest_to_audit_payload,
 )
+from meho_backplane.settings import get_settings
 
 __all__ = [
     "CompositeRecursionLimitExceeded",
@@ -2435,6 +2446,70 @@ async def dispatch(
     if validation_errors:
         return result_invalid_params(op_id, validation_errors, _elapsed_ms(started))
 
+    # --- Step 3.5: dispatch limits (#3500) --------------------------------
+    # Per-principal rate limit + per-principal concurrent-op cap, enforced
+    # here so CLI, MCP and the REST dispatch route are all covered by one
+    # seam (they all funnel through this function). Applied to TOP-LEVEL
+    # client requests only: a composite's internal ``dispatch_child`` fan-out
+    # (``composite_depth_var > 0``) is one client request, not many, and
+    # counting it would both misattribute volume and risk a self-deadlock
+    # against the cap; an approval-resume (``_approved``) is the continuation
+    # of a request already counted at park time. Both are exempt. Every limit
+    # defaults to disabled (0), so an unconfigured tenant reaches Step 4
+    # unchanged with no Valkey round-trip. A rejection is audited
+    # synchronously (``result_status='rate_limited'``) before any vendor
+    # traffic and surfaced as a structured 429-shaped envelope.
+    _dispatch_slot_key: str | None = None
+    if composite_depth_var.get() == COMPOSITE_DEPTH_TOP_LEVEL and not _approved:
+        _limit_settings = get_settings()
+        _rate_limit = resolve_dispatch_rate_limit(_limit_settings, operator.tenant_id)
+        _rate_retry = await check_dispatch_rate_limit(operator.tenant_id, operator.sub, _rate_limit)
+        if _rate_retry is not None:
+            duration_ms = _elapsed_ms(started)
+            await audit_and_broadcast_safe(
+                audit_id=uuid.uuid4(),
+                operator=operator,
+                descriptor=descriptor,
+                target=target,
+                params=params,
+                params_hash=params_hash,
+                result_status="rate_limited",
+                duration_ms=duration_ms,
+            )
+            return result_rate_limited(
+                op_id,
+                kind="rate",
+                limit=_rate_limit,
+                retry_after_seconds=_rate_retry,
+                duration_ms=duration_ms,
+            )
+        _conc_cap = resolve_dispatch_concurrency_cap(_limit_settings, operator.tenant_id)
+        _conc_retry, _dispatch_slot_key = await acquire_dispatch_slot(
+            operator.tenant_id,
+            operator.sub,
+            _conc_cap,
+            _limit_settings.dispatch_concurrency_slot_ttl_seconds,
+        )
+        if _conc_retry is not None:
+            duration_ms = _elapsed_ms(started)
+            await audit_and_broadcast_safe(
+                audit_id=uuid.uuid4(),
+                operator=operator,
+                descriptor=descriptor,
+                target=target,
+                params=params,
+                params_hash=params_hash,
+                result_status="rate_limited",
+                duration_ms=duration_ms,
+            )
+            return result_rate_limited(
+                op_id,
+                kind="concurrency",
+                limit=_conc_cap,
+                retry_after_seconds=_conc_retry,
+                duration_ms=duration_ms,
+            )
+
     # --- Step 4: policy gate ---------------------------------------------
     # Skipped on the approval-queue resume path (``_approved``): a human
     # operator already approved this exact call, so re-running the gate
@@ -2627,3 +2702,17 @@ async def dispatch(
     finally:
         policy_decision_var.reset(_verdict_token)
         reveal_secret_var.reset(_reveal_token)
+        # #3500: release the concurrency slot (no-op when none was taken --
+        # the disabled / non-top-level / approved paths). Best-effort: a
+        # release hiccup must not turn a decided result into an exception,
+        # and the slot's safety TTL is the backstop if the DECR never lands.
+        try:
+            await release_dispatch_slot(_dispatch_slot_key)
+        except Exception:
+            import structlog as _structlog
+
+            _structlog.get_logger(__name__).exception(
+                "dispatch_slot_release_failed",
+                op_id=op_id,
+                operator_sub=operator.sub,
+            )

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -107,6 +107,7 @@ from meho_backplane.operations.addon_orchestration import (
     bound_parent_linkage,
     resolve_or_open_orchestration_run,
 )
+from meho_backplane.operations.dispatch_limits import rate_limited_read_envelope
 from meho_backplane.operations.dispatcher import dispatch
 from meho_backplane.operations.ingest.list_connectors import next_step_for_registered_connector
 from meho_backplane.targets.resolver import (
@@ -813,7 +814,14 @@ async def search_operations(
     :class:`ConnectorNotIngestedError` with the ingest ``next_step`` hint
     (#1482); a *known* connector with no matching ops still returns an
     empty ``hits`` list (``200 []``).
+
+    #3500: per-principal dispatch rate limit. A burst of searches from one
+    principal over its per-minute cap is rejected with a structured
+    ``rate_limited`` envelope before any embedding / candidate query runs.
     """
+    rate_limited = await rate_limited_read_envelope(operator)
+    if rate_limited is not None:
+        return rate_limited
     connector_id = arguments["connector_id"]
     query = arguments["query"]
     group_key: str | None = arguments.get("group")
@@ -1223,7 +1231,14 @@ async def preview_operation(
     missing / empty / ``name``-less target, ``no_target`` for a
     supplied-but-unresolvable name (see :func:`_resolve_target_or_error`) —
     so ``call`` and ``preview`` behave the same for target resolution.
+
+    #3500: shares ``call_operation``'s per-principal dispatch rate limit —
+    a burst over the per-minute cap is rejected with a structured
+    ``rate_limited`` envelope before any target resolution.
     """
+    rate_limited = await rate_limited_read_envelope(operator)
+    if rate_limited is not None:
+        return rate_limited
     connector_id = arguments["connector_id"]
     op_id = arguments["op_id"]
     params: dict[str, Any] = arguments.get("params") or {}

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1248,6 +1248,48 @@ class Settings(BaseModel):
     #: a source may override the cap per-source via
     #: ``event_source.extras["rate_per_minute"]``.
     events_ingest_rate_per_minute: int = Field(default=60, ge=0)
+    #: #3500 -- per-principal dispatch rate limit (requests per minute).
+    #: Applied on the shared dispatch path (``call_operation`` /
+    #: ``search_operations`` / ``preview_operation`` / ``result_query``,
+    #: on CLI, MCP and the REST dispatch route alike), keyed
+    #: ``meho:ratelimit:dispatch:{tenant}:{principal}`` on the broadcast
+    #: Valkey. ``0`` (the default) disables the limit entirely -- no
+    #: Valkey round-trip -- so existing tenants are unaffected until an
+    #: operator opts in. Set via ``DISPATCH_RATE_LIMIT_PER_MINUTE``.
+    dispatch_rate_limit_per_minute: int = Field(default=0, ge=0)
+    #: #3500 -- per-tenant overrides for ``dispatch_rate_limit_per_minute``.
+    #: CSV of ``<tenant-uuid>=<int>`` pairs (case-insensitive UUID,
+    #: whitespace ignored); a tenant absent from the map uses the global
+    #: default. Lets a shared instance hold an untrusted-visitor tenant to
+    #: a tight cap while production tenants keep headroom. Set via
+    #: ``DISPATCH_RATE_LIMIT_PER_MINUTE_OVERRIDES``.
+    dispatch_rate_limit_per_minute_overrides: str = ""
+    #: #3500 -- per-principal cap on concurrent in-flight top-level
+    #: dispatches, keyed ``meho:concurrency:dispatch:{tenant}:{principal}``.
+    #: ``0`` (the default) disables the cap. Set via
+    #: ``DISPATCH_MAX_CONCURRENT_OPS``.
+    dispatch_max_concurrent_ops: int = Field(default=0, ge=0)
+    #: #3500 -- per-tenant overrides for ``dispatch_max_concurrent_ops``
+    #: (same ``<tenant-uuid>=<int>`` CSV shape). Set via
+    #: ``DISPATCH_MAX_CONCURRENT_OPS_OVERRIDES``.
+    dispatch_max_concurrent_ops_overrides: str = ""
+    #: #3500 -- safety TTL (seconds) armed on a concurrency slot so a slot
+    #: leaked by a crashed worker self-heals rather than wedging a
+    #: principal forever. The normal path releases the slot when the op
+    #: finishes; this only bounds the crash case, so it is set generously
+    #: (an hour) to avoid expiring a genuinely long-running op's slot
+    #: early. Set via ``DISPATCH_CONCURRENCY_SLOT_TTL_SECONDS``.
+    dispatch_concurrency_slot_ttl_seconds: int = Field(default=3600, gt=0)
+    #: #3500 -- per-tenant cap on new MCP sessions per minute. MEHO holds
+    #: no session store, so this bounds ``initialize`` handshakes per
+    #: window (each is one new session) -- the cheap, deterministic proxy
+    #: for a "concurrent sessions" cap. ``0`` (the default) disables it.
+    #: Set via ``MCP_SESSION_START_LIMIT_PER_MINUTE``.
+    mcp_session_start_limit_per_minute: int = Field(default=0, ge=0)
+    #: #3500 -- per-tenant overrides for
+    #: ``mcp_session_start_limit_per_minute`` (same ``<tenant-uuid>=<int>``
+    #: CSV shape). Set via ``MCP_SESSION_START_LIMIT_PER_MINUTE_OVERRIDES``.
+    mcp_session_start_limit_per_minute_overrides: str = ""
     #: Look-back window (minutes) for the dispatch-time target-activity
     #: advisory (#2550). A write-class dispatch on a target with peer
     #: activity inside this window carries a compact
@@ -2177,6 +2219,30 @@ def get_settings() -> Settings:
         events_ingest_rate_per_minute=int(
             os.environ.get("EVENTS_INGEST_RATE_PER_MINUTE", "60"),
         ),
+        dispatch_rate_limit_per_minute=int(
+            os.environ.get("DISPATCH_RATE_LIMIT_PER_MINUTE", "0"),
+        ),
+        dispatch_rate_limit_per_minute_overrides=os.environ.get(
+            "DISPATCH_RATE_LIMIT_PER_MINUTE_OVERRIDES",
+            "",
+        ).strip(),
+        dispatch_max_concurrent_ops=int(
+            os.environ.get("DISPATCH_MAX_CONCURRENT_OPS", "0"),
+        ),
+        dispatch_max_concurrent_ops_overrides=os.environ.get(
+            "DISPATCH_MAX_CONCURRENT_OPS_OVERRIDES",
+            "",
+        ).strip(),
+        dispatch_concurrency_slot_ttl_seconds=int(
+            os.environ.get("DISPATCH_CONCURRENCY_SLOT_TTL_SECONDS", "3600"),
+        ),
+        mcp_session_start_limit_per_minute=int(
+            os.environ.get("MCP_SESSION_START_LIMIT_PER_MINUTE", "0"),
+        ),
+        mcp_session_start_limit_per_minute_overrides=os.environ.get(
+            "MCP_SESSION_START_LIMIT_PER_MINUTE_OVERRIDES",
+            "",
+        ).strip(),
         dispatch_activity_advisory_window_minutes=int(
             os.environ.get("DISPATCH_ACTIVITY_ADVISORY_WINDOW_MINUTES", "30"),
         ),

--- a/backend/tests/test_dispatch_limits.py
+++ b/backend/tests/test_dispatch_limits.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-principal dispatch rate limit + concurrent-op cap unit tests (#3500).
+
+Drives :mod:`meho_backplane.operations.dispatch_limits` against an in-memory
+fake Valkey (no socket), mirroring ``test_events_ingest_rate_limit.py``.
+Acceptance-criteria coverage:
+
+* the ``limit+1``-th dispatch in one window is rejected with a retry-after
+  (criterion 1 / rate-limit) and a fresh window refills the budget
+* a second principal in the same tenant is unaffected (per-``(tenant,
+  principal)`` counter)
+* the per-tenant override wins over the global default (criterion 3)
+* the concurrent-op cap admits up to ``cap`` in-flight dispatches, rejects
+  the next, and a release frees a slot (criterion 2)
+* a limit / cap of ``0`` disables the control with no Valkey round-trip
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.operations import dispatch_limits
+from meho_backplane.operations.dispatch_limits import (
+    acquire_dispatch_slot,
+    check_dispatch_rate_limit,
+    rate_limited_read_envelope,
+    release_dispatch_slot,
+    resolve_dispatch_concurrency_cap,
+    resolve_dispatch_rate_limit,
+    resolve_int_override,
+)
+
+_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000d1")
+_OTHER_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000d2")
+_FIXED_NOW = 1_700_000_030.0  # int(now) % 60 == 50, so retry_after == 10
+
+
+class _FakePipeline:
+    def __init__(self, store: dict[str, int]) -> None:
+        self._store = store
+        self._ops: list[tuple[str, str, int]] = []
+
+    async def __aenter__(self) -> _FakePipeline:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    def incr(self, name: str, amount: int = 1) -> None:
+        self._ops.append(("incr", name, amount))
+
+    def expire(self, name: str, time: int, *args: object, **kwargs: object) -> None:
+        self._ops.append(("expire", name, time))
+
+    async def execute(self) -> list[Any]:
+        results: list[Any] = []
+        for op, name, arg in self._ops:
+            if op == "incr":
+                self._store[name] = self._store.get(name, 0) + arg
+                results.append(self._store[name])
+            else:
+                results.append(True)
+        return results
+
+
+class _FakeValkey:
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+        self.pipeline_calls = 0
+
+    def pipeline(self, transaction: bool = True) -> _FakePipeline:
+        self.pipeline_calls += 1
+        return _FakePipeline(self.store)
+
+    async def decr(self, name: str, amount: int = 1) -> int:
+        self.store[name] = self.store.get(name, 0) - amount
+        return self.store[name]
+
+    async def delete(self, name: str) -> int:
+        return 1 if self.store.pop(name, None) is not None else 0
+
+
+@pytest.fixture
+def fake_valkey(monkeypatch: pytest.MonkeyPatch) -> _FakeValkey:
+    fake = _FakeValkey()
+    monkeypatch.setattr(
+        "meho_backplane.operations.dispatch_limits.get_broadcast_client",
+        lambda: fake,
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations.dispatch_limits.time.time",
+        lambda: _FIXED_NOW,
+    )
+    return fake
+
+
+# --- resolver (pure, no Valkey) ------------------------------------------
+
+
+def test_resolve_int_override_empty_uses_default() -> None:
+    assert resolve_int_override("", _TENANT, 42) == 42
+
+
+def test_resolve_int_override_matches_tenant_case_insensitive() -> None:
+    csv = f"{str(_TENANT).upper()}=5, {_OTHER_TENANT}=9"
+    assert resolve_int_override(csv, _TENANT, 100) == 5
+
+
+def test_resolve_int_override_absent_tenant_falls_back() -> None:
+    assert resolve_int_override(f"{_OTHER_TENANT}=9", _TENANT, 100) == 100
+
+
+def test_resolve_int_override_skips_malformed_entries() -> None:
+    # A bad-uuid entry and a bad-int entry are skipped; the valid one wins.
+    csv = f"not-a-uuid=3, {_TENANT}=nope, {_TENANT}=7"
+    assert resolve_int_override(csv, _TENANT, 100) == 7
+
+
+def test_resolve_dispatch_rate_limit_prefers_override() -> None:
+    settings = SimpleNamespace(
+        dispatch_rate_limit_per_minute=100,
+        dispatch_rate_limit_per_minute_overrides=f"{_TENANT}=5",
+    )
+    assert resolve_dispatch_rate_limit(settings, _TENANT) == 5
+    assert resolve_dispatch_rate_limit(settings, _OTHER_TENANT) == 100
+
+
+def test_resolve_dispatch_concurrency_cap_prefers_override() -> None:
+    settings = SimpleNamespace(
+        dispatch_max_concurrent_ops=20,
+        dispatch_max_concurrent_ops_overrides=f"{_TENANT}=2",
+    )
+    assert resolve_dispatch_concurrency_cap(settings, _TENANT) == 2
+    assert resolve_dispatch_concurrency_cap(settings, _OTHER_TENANT) == 20
+
+
+# --- rate limit ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rate_within_limit_passes(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        assert await check_dispatch_rate_limit(_TENANT, "p1", 3) is None
+
+
+@pytest.mark.asyncio
+async def test_rate_over_limit_rejected_with_retry_after(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        assert await check_dispatch_rate_limit(_TENANT, "p1", 3) is None
+    retry = await check_dispatch_rate_limit(_TENANT, "p1", 3)
+    # int(_FIXED_NOW) % 60 == 50, so the window rolls over in 10 s.
+    assert retry == 10
+
+
+@pytest.mark.asyncio
+async def test_rate_window_rollover_refills(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeValkey()
+    monkeypatch.setattr(
+        "meho_backplane.operations.dispatch_limits.get_broadcast_client",
+        lambda: fake,
+    )
+    clock = {"now": _FIXED_NOW}
+    monkeypatch.setattr(
+        "meho_backplane.operations.dispatch_limits.time.time",
+        lambda: clock["now"],
+    )
+    for _ in range(3):
+        assert await check_dispatch_rate_limit(_TENANT, "p1", 3) is None
+    assert await check_dispatch_rate_limit(_TENANT, "p1", 3) == 10
+    # Advance into the next window: the budget refills (a new bucket key).
+    clock["now"] = _FIXED_NOW + 60
+    assert await check_dispatch_rate_limit(_TENANT, "p1", 3) is None
+
+
+@pytest.mark.asyncio
+async def test_rate_per_principal_isolation(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        await check_dispatch_rate_limit(_TENANT, "p1", 3)
+    assert await check_dispatch_rate_limit(_TENANT, "p1", 3) == 10
+    # A different principal in the same tenant has its own budget.
+    assert await check_dispatch_rate_limit(_TENANT, "p2", 3) is None
+
+
+@pytest.mark.asyncio
+async def test_rate_disabled_no_round_trip(fake_valkey: _FakeValkey) -> None:
+    assert await check_dispatch_rate_limit(_TENANT, "p1", 0) is None
+    assert fake_valkey.pipeline_calls == 0
+
+
+# --- concurrency cap -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrency_admits_up_to_cap(fake_valkey: _FakeValkey) -> None:
+    keys = []
+    for _ in range(2):
+        retry, key = await acquire_dispatch_slot(_TENANT, "p1", 2, 3600)
+        assert retry is None
+        assert key is not None
+        keys.append(key)
+    # The 3rd concurrent acquire is over the cap of 2.
+    retry, key = await acquire_dispatch_slot(_TENANT, "p1", 2, 3600)
+    assert retry == dispatch_limits.DISPATCH_CONCURRENCY_RETRY_AFTER_SECONDS
+    assert key is None
+
+
+@pytest.mark.asyncio
+async def test_concurrency_release_frees_slot(fake_valkey: _FakeValkey) -> None:
+    _, key1 = await acquire_dispatch_slot(_TENANT, "p1", 2, 3600)
+    _, _key2 = await acquire_dispatch_slot(_TENANT, "p1", 2, 3600)
+    # At the cap: next is rejected.
+    retry, rejected = await acquire_dispatch_slot(_TENANT, "p1", 2, 3600)
+    assert retry is not None and rejected is None
+    # Release one slot; a fresh acquire now succeeds.
+    await release_dispatch_slot(key1)
+    retry, key3 = await acquire_dispatch_slot(_TENANT, "p1", 2, 3600)
+    assert retry is None and key3 is not None
+
+
+@pytest.mark.asyncio
+async def test_concurrency_reject_does_not_leak_slot(fake_valkey: _FakeValkey) -> None:
+    key = dispatch_limits._concurrency_key(_TENANT, "p1")
+    await acquire_dispatch_slot(_TENANT, "p1", 1, 3600)  # count -> 1 (at cap)
+    await acquire_dispatch_slot(_TENANT, "p1", 1, 3600)  # rejected, rolled back
+    # The rejected attempt rolled its increment back, so the counter still
+    # reflects exactly the one held slot.
+    assert fake_valkey.store.get(key) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrency_disabled_no_round_trip(fake_valkey: _FakeValkey) -> None:
+    retry, key = await acquire_dispatch_slot(_TENANT, "p1", 0, 3600)
+    assert retry is None and key is None
+    assert fake_valkey.pipeline_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_release_none_is_noop(fake_valkey: _FakeValkey) -> None:
+    await release_dispatch_slot(None)  # no raise, no Valkey call
+    assert fake_valkey.store == {}
+
+
+@pytest.mark.asyncio
+async def test_release_reaps_key_at_zero(fake_valkey: _FakeValkey) -> None:
+    _, key = await acquire_dispatch_slot(_TENANT, "p1", 5, 3600)
+    assert key is not None and fake_valkey.store.get(key) == 1
+    await release_dispatch_slot(key)
+    # Deleted at zero rather than left at 0 (keeps the counter non-negative).
+    assert key not in fake_valkey.store
+
+
+# --- read-path envelope --------------------------------------------------
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="reader-1",
+        raw_jwt="x",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_envelope_none_under_limit(
+    fake_valkey: _FakeValkey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "meho_backplane.operations.dispatch_limits.get_settings",
+        lambda: SimpleNamespace(
+            dispatch_rate_limit_per_minute=2,
+            dispatch_rate_limit_per_minute_overrides="",
+        ),
+    )
+    assert await rate_limited_read_envelope(_operator()) is None
+
+
+@pytest.mark.asyncio
+async def test_read_envelope_returned_over_limit(
+    fake_valkey: _FakeValkey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "meho_backplane.operations.dispatch_limits.get_settings",
+        lambda: SimpleNamespace(
+            dispatch_rate_limit_per_minute=1,
+            dispatch_rate_limit_per_minute_overrides="",
+        ),
+    )
+    op = _operator()
+    assert await rate_limited_read_envelope(op) is None  # 1st within cap of 1
+    envelope = await rate_limited_read_envelope(op)  # 2nd over cap
+    assert envelope is not None
+    assert envelope["status"] == "rate_limited"
+    assert envelope["error_code"] == "rate_limited"
+    assert envelope["retry_after_seconds"] == 10

--- a/backend/tests/test_dispatcher_rate_limit_integration.py
+++ b/backend/tests/test_dispatcher_rate_limit_integration.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dispatcher wiring for the #3500 dispatch limits.
+
+Proves the ``dispatch()`` integration contract without a live connector or
+vendor round-trip, by stubbing the dispatcher's seams (descriptor lookup,
+param validation, the limit primitives, the audit writer, the policy gate):
+
+* an over-rate-limit dispatch returns a ``rate_limited`` envelope, writes an
+  audit row with ``result_status='rate_limited'``, and never reaches the
+  policy gate / execution (no vendor traffic) — acceptance criterion "over-
+  limit events are audited"
+* an over-concurrency-cap dispatch behaves the same with ``kind='concurrency'``
+* a dispatch that passes both limits acquires a slot and releases it in the
+  ``finally`` even when a later step (here: a policy denial) returns early
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import meho_backplane.operations.dispatcher as dispatcher
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.models import PermissionVerdict
+from meho_backplane.operations import dispatch
+
+_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000f1")
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="limit-principal",
+        raw_jwt="x",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture
+def stub_dispatch_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]:
+    """Stub the dispatcher seams reached before + at the #3500 limit block."""
+    descriptor = SimpleNamespace(source_kind="typed", parameter_schema={}, op_id="svc.read")
+    monkeypatch.setattr(dispatcher, "lookup_descriptor", AsyncMock(return_value=descriptor))
+    monkeypatch.setattr(dispatcher, "validate_params", lambda schema, params: [])
+    monkeypatch.setattr(
+        dispatcher,
+        "get_settings",
+        lambda: SimpleNamespace(dispatch_concurrency_slot_ttl_seconds=3600),
+    )
+    audit = AsyncMock()
+    monkeypatch.setattr(dispatcher, "audit_and_broadcast_safe", audit)
+    gate = AsyncMock()
+    monkeypatch.setattr(dispatcher, "policy_gate", gate)
+    release = AsyncMock()
+    monkeypatch.setattr(dispatcher, "release_dispatch_slot", release)
+    return {"audit": audit, "gate": gate, "release": release}
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_rejection_is_audited_and_skips_execution(
+    stub_dispatch_seams: dict[str, AsyncMock], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(dispatcher, "resolve_dispatch_rate_limit", lambda s, t: 5)
+    monkeypatch.setattr(dispatcher, "check_dispatch_rate_limit", AsyncMock(return_value=30))
+
+    result = await dispatch(
+        operator=_operator(),
+        connector_id="svc-1.0",
+        op_id="svc.read",
+        target=None,
+        params={},
+    )
+
+    assert result.status == "rate_limited"
+    assert result.extras["kind"] == "rate"
+    assert result.extras["retry_after_seconds"] == 30
+    # Audited with result_status='rate_limited' ...
+    stub_dispatch_seams["audit"].assert_awaited_once()
+    assert stub_dispatch_seams["audit"].await_args.kwargs["result_status"] == "rate_limited"
+    # ... and the policy gate / execution were never reached (no vendor traffic).
+    stub_dispatch_seams["gate"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrency_rejection_is_audited_and_skips_execution(
+    stub_dispatch_seams: dict[str, AsyncMock], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(dispatcher, "resolve_dispatch_rate_limit", lambda s, t: 0)
+    monkeypatch.setattr(dispatcher, "check_dispatch_rate_limit", AsyncMock(return_value=None))
+    monkeypatch.setattr(dispatcher, "resolve_dispatch_concurrency_cap", lambda s, t: 2)
+    monkeypatch.setattr(dispatcher, "acquire_dispatch_slot", AsyncMock(return_value=(1, None)))
+
+    result = await dispatch(
+        operator=_operator(),
+        connector_id="svc-1.0",
+        op_id="svc.read",
+        target=None,
+        params={},
+    )
+
+    assert result.status == "rate_limited"
+    assert result.extras["kind"] == "concurrency"
+    stub_dispatch_seams["audit"].assert_awaited_once()
+    assert stub_dispatch_seams["audit"].await_args.kwargs["result_status"] == "rate_limited"
+    stub_dispatch_seams["gate"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acquired_slot_released_even_on_early_return(
+    stub_dispatch_seams: dict[str, AsyncMock], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Both limits pass; a slot is acquired, then the policy gate denies and
+    # dispatch returns early from inside the try — the finally must release.
+    monkeypatch.setattr(dispatcher, "resolve_dispatch_rate_limit", lambda s, t: 0)
+    monkeypatch.setattr(dispatcher, "check_dispatch_rate_limit", AsyncMock(return_value=None))
+    monkeypatch.setattr(dispatcher, "resolve_dispatch_concurrency_cap", lambda s, t: 2)
+    monkeypatch.setattr(
+        dispatcher, "acquire_dispatch_slot", AsyncMock(return_value=(None, "slot-key-1"))
+    )
+    stub_dispatch_seams["gate"].return_value = (PermissionVerdict.DENY, "policy denied")
+
+    result = await dispatch(
+        operator=_operator(),
+        connector_id="svc-1.0",
+        op_id="svc.read",
+        target=None,
+        params={},
+    )
+
+    assert result.status == "denied"
+    stub_dispatch_seams["gate"].assert_awaited_once()
+    stub_dispatch_seams["release"].assert_awaited_once_with("slot-key-1")

--- a/backend/tests/test_dispatcher_rate_limit_integration.py
+++ b/backend/tests/test_dispatcher_rate_limit_integration.py
@@ -54,11 +54,13 @@ def stub_dispatch_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, AsyncMock]
     )
     audit = AsyncMock()
     monkeypatch.setattr(dispatcher, "audit_and_broadcast_safe", audit)
+    reject = AsyncMock()
+    monkeypatch.setattr(dispatcher, "audit_rejection_safe", reject)
     gate = AsyncMock()
     monkeypatch.setattr(dispatcher, "policy_gate", gate)
     release = AsyncMock()
     monkeypatch.setattr(dispatcher, "release_dispatch_slot", release)
-    return {"audit": audit, "gate": gate, "release": release}
+    return {"audit": audit, "reject": reject, "gate": gate, "release": release}
 
 
 @pytest.mark.asyncio
@@ -79,9 +81,10 @@ async def test_rate_limit_rejection_is_audited_and_skips_execution(
     assert result.status == "rate_limited"
     assert result.extras["kind"] == "rate"
     assert result.extras["retry_after_seconds"] == 30
-    # Audited with result_status='rate_limited' ...
-    stub_dispatch_seams["audit"].assert_awaited_once()
-    assert stub_dispatch_seams["audit"].await_args.kwargs["result_status"] == "rate_limited"
+    # Audited (row only, no broadcast) with result_status='rate_limited' ...
+    stub_dispatch_seams["reject"].assert_awaited_once()
+    assert stub_dispatch_seams["reject"].await_args.kwargs["result_status"] == "rate_limited"
+    stub_dispatch_seams["audit"].assert_not_awaited()  # no broadcast amplification
     # ... and the policy gate / execution were never reached (no vendor traffic).
     stub_dispatch_seams["gate"].assert_not_awaited()
 
@@ -105,8 +108,9 @@ async def test_concurrency_rejection_is_audited_and_skips_execution(
 
     assert result.status == "rate_limited"
     assert result.extras["kind"] == "concurrency"
-    stub_dispatch_seams["audit"].assert_awaited_once()
-    assert stub_dispatch_seams["audit"].await_args.kwargs["result_status"] == "rate_limited"
+    stub_dispatch_seams["reject"].assert_awaited_once()
+    assert stub_dispatch_seams["reject"].await_args.kwargs["result_status"] == "rate_limited"
+    stub_dispatch_seams["audit"].assert_not_awaited()  # no broadcast amplification
     stub_dispatch_seams["gate"].assert_not_awaited()
 
 

--- a/backend/tests/test_mcp_session_limit.py
+++ b/backend/tests/test_mcp_session_limit.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tenant MCP session-start cap unit tests (#3500).
+
+Drives :mod:`meho_backplane.mcp.session_limit` against an in-memory fake
+Valkey, mirroring ``test_events_ingest_rate_limit.py``. Acceptance-criteria
+coverage:
+
+* the ``cap+1``-th ``initialize`` in one window is rejected with a
+  retry-after; a fresh window refills the budget
+* the per-tenant override wins over the global default
+* a cap of ``0`` disables the control with no Valkey round-trip
+* a second tenant is unaffected (per-tenant counter)
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from meho_backplane.mcp.session_limit import (
+    check_mcp_session_cap,
+    resolve_mcp_session_cap,
+)
+
+_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000e1")
+_OTHER_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000e2")
+_FIXED_NOW = 1_700_000_030.0  # int(now) % 60 == 50, so retry_after == 10
+
+
+class _FakePipeline:
+    def __init__(self, store: dict[str, int]) -> None:
+        self._store = store
+        self._ops: list[tuple[str, str, int]] = []
+
+    async def __aenter__(self) -> _FakePipeline:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    def incr(self, name: str, amount: int = 1) -> None:
+        self._ops.append(("incr", name, amount))
+
+    def expire(self, name: str, time: int, *args: object, **kwargs: object) -> None:
+        self._ops.append(("expire", name, time))
+
+    async def execute(self) -> list[Any]:
+        results: list[Any] = []
+        for op, name, arg in self._ops:
+            if op == "incr":
+                self._store[name] = self._store.get(name, 0) + arg
+                results.append(self._store[name])
+            else:
+                results.append(True)
+        return results
+
+
+class _FakeValkey:
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+        self.pipeline_calls = 0
+
+    def pipeline(self, transaction: bool = True) -> _FakePipeline:
+        self.pipeline_calls += 1
+        return _FakePipeline(self.store)
+
+
+@pytest.fixture
+def fake_valkey(monkeypatch: pytest.MonkeyPatch) -> _FakeValkey:
+    fake = _FakeValkey()
+    monkeypatch.setattr(
+        "meho_backplane.mcp.session_limit.get_broadcast_client",
+        lambda: fake,
+    )
+    monkeypatch.setattr(
+        "meho_backplane.mcp.session_limit.time.time",
+        lambda: _FIXED_NOW,
+    )
+    return fake
+
+
+def test_resolve_session_cap_prefers_override() -> None:
+    settings = SimpleNamespace(
+        mcp_session_start_limit_per_minute=50,
+        mcp_session_start_limit_per_minute_overrides=f"{_TENANT}=3",
+    )
+    assert resolve_mcp_session_cap(settings, _TENANT) == 3
+    assert resolve_mcp_session_cap(settings, _OTHER_TENANT) == 50
+
+
+@pytest.mark.asyncio
+async def test_within_cap_passes(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        assert await check_mcp_session_cap(_TENANT, 3) is None
+
+
+@pytest.mark.asyncio
+async def test_over_cap_rejected_with_retry_after(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        assert await check_mcp_session_cap(_TENANT, 3) is None
+    assert await check_mcp_session_cap(_TENANT, 3) == 10
+
+
+@pytest.mark.asyncio
+async def test_window_rollover_refills(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeValkey()
+    monkeypatch.setattr(
+        "meho_backplane.mcp.session_limit.get_broadcast_client",
+        lambda: fake,
+    )
+    clock = {"now": _FIXED_NOW}
+    monkeypatch.setattr(
+        "meho_backplane.mcp.session_limit.time.time",
+        lambda: clock["now"],
+    )
+    for _ in range(2):
+        assert await check_mcp_session_cap(_TENANT, 2) is None
+    assert await check_mcp_session_cap(_TENANT, 2) == 10
+    clock["now"] = _FIXED_NOW + 60
+    assert await check_mcp_session_cap(_TENANT, 2) is None
+
+
+@pytest.mark.asyncio
+async def test_per_tenant_isolation(fake_valkey: _FakeValkey) -> None:
+    for _ in range(2):
+        await check_mcp_session_cap(_TENANT, 2)
+    assert await check_mcp_session_cap(_TENANT, 2) == 10
+    # A different tenant has its own budget.
+    assert await check_mcp_session_cap(_OTHER_TENANT, 2) is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_no_round_trip(fake_valkey: _FakeValkey) -> None:
+    assert await check_mcp_session_cap(_TENANT, 0) is None
+    assert fake_valkey.pipeline_calls == 0

--- a/docs/codebase/rate-limiting.md
+++ b/docs/codebase/rate-limiting.md
@@ -1,0 +1,137 @@
+# rate-limiting — per-principal / per-tenant dispatch limits (#3500)
+
+## Overview
+
+Before #3500 MEHO had **no application-level limiter on the dispatch
+surface**. The only request rate limits were the event-ingest webhook
+(`events/ingest/rate_limit.py`) and the agent broadcast-announce
+(`broadcast/rate_limit.py`); the `identity_budget` / `budget_enforcement`
+machinery caps only MEHO's **own internal** agent-run LLM spend, not a
+client's `call_operation` / `search_operations` request volume. On a shared
+instance hosting an untrusted-visitor tenant, one curious visitor — or a
+runaway agent loop — could exhaust DB / connector pools, CPU, and (via
+triggered internal agent runs) the server-side LLM budget, degrading every
+tenant. There was no server-side backstop.
+
+#3500 adds three controls, all **off by default** (every limit defaults to
+`0` = unlimited), so existing tenants are unaffected until an operator opts
+in. Each is a global default plus a per-tenant override expressed purely in
+settings (no migration, mirroring `agent_runs_disabled_tenants`):
+
+1. **Per-principal dispatch rate limit** — a per-`(tenant, principal)`
+   fixed-window request cap (per minute). A burst above the cap is rejected
+   with a `retry_after_seconds` hint.
+2. **Per-principal concurrent-op cap** — a per-`(tenant, principal)` count
+   of in-flight top-level dispatches, acquired before an op executes and
+   released when it finishes.
+3. **Per-tenant MCP session cap** — a per-tenant fixed-window cap on new
+   MCP `initialize` handshakes (see "Session cap" below).
+
+All three reuse the fixed-window `INCR` + `EXPIRE` shape the two pre-existing
+limiters already proved on the shared Valkey (the broadcast client). A
+token-bucket algorithm was considered and rejected for v1: the fixed-window
+counter is atomic on a single `INCR` (no Lua / no read-modify-write race),
+matches the codebase's two other limiters and their test harness, and
+satisfies the "a burst is throttled" acceptance criterion. If burst-carryover
+semantics are ever needed, that is a follow-up refinement.
+
+## Key types
+
+| Symbol | Where | Role |
+|---|---|---|
+| `check_dispatch_rate_limit(tenant_id, sub, limit)` | `operations/dispatch_limits.py` | Increments the window counter; returns `retry_after` seconds when over `limit`, else `None`. `limit<=0` → no Valkey round-trip. |
+| `acquire_dispatch_slot(tenant_id, sub, cap, ttl)` | `operations/dispatch_limits.py` | Takes one in-flight slot; returns `(retry_after, None)` when over `cap` (increment rolled back), else `(None, key)`. |
+| `release_dispatch_slot(key)` | `operations/dispatch_limits.py` | Releases a slot (`DECR`, deleting the key at zero); `None` is a no-op. |
+| `rate_limited_read_envelope(operator)` | `operations/dispatch_limits.py` | Shared rate check for the read-path meta-tools; returns a `rate_limited` envelope dict or `None`. |
+| `resolve_dispatch_rate_limit` / `resolve_dispatch_concurrency_cap` | `operations/dispatch_limits.py` | Resolve the effective limit for a tenant (per-tenant override wins over the global default). |
+| `resolve_int_override(csv, tenant_id, default)` | `operations/dispatch_limits.py` | Parse a `<uuid>=<int>` CSV override map; malformed entries are skipped with a warning. |
+| `check_mcp_session_cap(tenant_id, cap)` | `mcp/session_limit.py` | Per-tenant fixed-window cap on new `initialize` handshakes. |
+| `result_rate_limited(...)` | `operations/_errors.py` | The `OperationResult` builder (`status='rate_limited'`, `extras.retry_after_seconds`). |
+
+## Control flow
+
+**Rate limit + concurrency cap** are enforced in
+`operations/dispatcher.py::dispatch()` — the single entry point every
+`call_operation` funnels through on **CLI, MCP and the REST dispatch route**
+alike, so one seam covers all fronts (the CLAUDE.md postulate that CLI and
+MCP share the dispatch path). The gate runs after descriptor lookup + param
+validation and before the policy gate, and only for **top-level** requests:
+
+- A composite's internal `dispatch_child` fan-out (`composite_depth_var > 0`)
+  is one client request, not many — counting it would misattribute volume and
+  risk a self-deadlock against the cap.
+- An approval-resume (`_approved=True`) is the continuation of a request
+  already counted at park time.
+
+Both are exempt. On a rejection the dispatcher writes a synchronous audit row
+(`audit_and_broadcast_safe(result_status='rate_limited')`) — before any vendor
+traffic — and returns `result_rate_limited(...)`. `status_code_for_result`
+maps `rate_limited` → a synthetic `429` on the audit row. The concurrency slot
+is released in the dispatcher's `finally` (best-effort: a release failure is
+logged, not raised, and the slot's safety `ttl` is the backstop).
+
+The read-path meta-tools that do not go through `dispatch()` —
+`search_operations`, `preview_operation`, and the shared `result_query` cores
+(`read_result_window` / `run_result_query`) — call `rate_limited_read_envelope`
+at entry and return the same structured envelope. They share the one
+per-principal dispatch rate bucket (a caller's total working-surface request
+volume is bounded), and do no vendor traffic, so they carry no concurrency cap
+or dedicated audit row.
+
+**Session cap.** MEHO holds **no stateful MCP session store** — a session id
+is issued on `initialize` purely for audit correlation and then forgotten
+(`mcp/server.py::_issue_mcp_session_id`). A precise "concurrent sessions" count
+is therefore unknowable without building a session registry, which #3500 did
+not do. The cheap, deterministic backstop is a per-tenant cap on **new session
+handshakes per window**: every `initialize` is one new session, so bounding
+`initialize` volume bounds session creation. `_initialize` calls
+`_enforce_mcp_session_cap` first; over the cap it raises `McpRateLimitedError`
+(JSON-RPC `-32000`) with a `retry_after_seconds` hint.
+
+## Settings
+
+All default to disabled. Per-tenant override CSV is `<tenant-uuid>=<int>`
+pairs (case-insensitive UUID, whitespace ignored); a tenant absent from the
+map uses the global default.
+
+| Setting / env | Default | Meaning |
+|---|---|---|
+| `dispatch_rate_limit_per_minute` / `DISPATCH_RATE_LIMIT_PER_MINUTE` | `0` | Global per-principal dispatch requests/min. |
+| `dispatch_rate_limit_per_minute_overrides` / `..._OVERRIDES` | `""` | Per-tenant override map. |
+| `dispatch_max_concurrent_ops` / `DISPATCH_MAX_CONCURRENT_OPS` | `0` | Global per-principal in-flight-dispatch cap. |
+| `dispatch_max_concurrent_ops_overrides` / `..._OVERRIDES` | `""` | Per-tenant override map. |
+| `dispatch_concurrency_slot_ttl_seconds` / `DISPATCH_CONCURRENCY_SLOT_TTL_SECONDS` | `3600` | Safety TTL so a slot leaked by a crashed worker self-heals. |
+| `mcp_session_start_limit_per_minute` / `MCP_SESSION_START_LIMIT_PER_MINUTE` | `0` | Global per-tenant new-MCP-sessions/min. |
+| `mcp_session_start_limit_per_minute_overrides` / `..._OVERRIDES` | `""` | Per-tenant override map. |
+
+The lab enables tight caps for the untrusted-visitor (Envision) tenant only,
+leaving production tenants at the unlimited default.
+
+## Dependencies
+
+- The shared broadcast Valkey via `broadcast.client.get_broadcast_client` —
+  the same client the announce + ingest limiters use.
+- Key namespaces (distinct from the announce/ingest/feed keys):
+  `meho:ratelimit:dispatch:{tenant}:{principal}:{bucket}`,
+  `meho:concurrency:dispatch:{tenant}:{principal}`,
+  `meho:ratelimit:mcpsession:{tenant}:{bucket}`.
+- Prometheus counters: `dispatch_rate_limited_total`,
+  `dispatch_concurrency_limited_total`, `mcp_session_limited_total`.
+
+## Known issues / limits
+
+- **Fail-loud on a Valkey outage** — a redis-py failure propagates verbatim
+  (consistent with the two existing limiters). Failing the dispatch closed is
+  the safe posture for an abuse control; failing open would let a principal
+  bypass the cap during a Valkey wobble.
+- The concurrency cap is a counter, not a lease: a slot leaked by a crashed
+  worker (release never runs) self-heals only when the safety `ttl` expires.
+- The session cap is a **new-sessions-per-window** proxy, not a live
+  concurrent-session count — MEHO holds no session registry to count against.
+
+## References
+
+- Task: `evoila/meho#3500`; finding: `evoila-bosnia/meho-internal#321`.
+- Prior art: `broadcast/rate_limit.py`, `events/ingest/rate_limit.py`.
+- Not this: `operations/budget_enforcement.py` / `identity-budget.md`
+  (internal agent-run LLM spend only, not client request volume).

--- a/docs/codebase/rate-limiting.md
+++ b/docs/codebase/rate-limiting.md
@@ -64,19 +64,22 @@ validation and before the policy gate, and only for **top-level** requests:
   already counted at park time.
 
 Both are exempt. On a rejection the dispatcher writes a synchronous audit row
-(`audit_and_broadcast_safe(result_status='rate_limited')`) — before any vendor
-traffic — and returns `result_rate_limited(...)`. `status_code_for_result`
+(`audit_rejection_safe(result_status='rate_limited')`) — before any vendor
+traffic — and returns `result_rate_limited(...)`. Unlike a policy denial, a
+rate-limit rejection is audited **row-only, with no broadcast**: emitting one
+broadcast per over-limit request would amplify the very load the limiter sheds
+and spam the tenant feed. The audit write is fail-open (a rejected request
+changed nothing). `status_code_for_result`
 maps `rate_limited` → a synthetic `429` on the audit row. The concurrency slot
 is released in the dispatcher's `finally` (best-effort: a release failure is
 logged, not raised, and the slot's safety `ttl` is the backstop).
 
-The read-path meta-tools that do not go through `dispatch()` —
-`search_operations`, `preview_operation`, and the shared `result_query` cores
-(`read_result_window` / `run_result_query`) — call `rate_limited_read_envelope`
-at entry and return the same structured envelope. They share the one
-per-principal dispatch rate bucket (a caller's total working-surface request
-volume is bounded), and do no vendor traffic, so they carry no concurrency cap
-or dedicated audit row.
+The read-path meta-tools `search_operations` and `preview_operation` (which do
+not go through `dispatch()`) call `rate_limited_read_envelope` at entry and
+return the same structured envelope. They share the one per-principal dispatch
+rate bucket (a caller's total working-surface request volume is bounded), and
+do no vendor traffic, so they carry no concurrency cap or dedicated audit row.
+`result_query` is intentionally **not** gated — see "Known issues / limits".
 
 **Session cap.** MEHO holds **no stateful MCP session store** — a session id
 is issued on `initialize` purely for audit correlation and then forgotten
@@ -126,6 +129,13 @@ leaving production tenants at the unlimited default.
   bypass the cap during a Valkey wobble.
 - The concurrency cap is a counter, not a lease: a slot leaked by a crashed
   worker (release never runs) self-heals only when the safety `ttl` expires.
+- `result_query` (the JSONFlux handle drill-in) is deliberately not
+  separately rate-limited: it is a bounded read over the caller's own
+  already-spilled, tenant+principal-isolated handle (low abuse value), it
+  follows a `call_operation` that already spent a rate token, and gating its
+  pure query cores would couple them to full `Settings` construction. The
+  discovery/execution paths (`call_operation`, `search_operations`,
+  `preview_operation`) carry the limit.
 - The session cap is a **new-sessions-per-window** proxy, not a live
   concurrent-session count — MEHO holds no session registry to count against.
 


### PR DESCRIPTION
## Summary
- Adds a server-side abuse backstop on the dispatch surface: a **per-principal dispatch rate limit** + **per-principal concurrent-op cap** enforced in the shared `dispatch()` seam (covering `call_operation` on CLI, MCP and the REST dispatch route), plus a **per-tenant cap on new MCP sessions per window** at `initialize`. `search_operations` and `preview_operation` share the per-principal rate bucket.
- Every limit is a global default + per-tenant settings override and defaults to **disabled (`0` = unlimited)**, so existing tenants are unaffected until an operator opts in (the lab enables tight caps for the Envision visitor tenant only).
- Over-limit dispatches return a structured `rate_limited` (429-shaped) envelope and are **audited synchronously** (`result_status='rate_limited'`) before any vendor traffic. Reuses the fixed-window `INCR`+`EXPIRE` Valkey shape the announce + ingest limiters already use (no Lua, no migration, no new MCP tool).

## Design notes
- The rate limit uses a **fixed-window** counter (like `broadcast/rate_limit.py` + `events/ingest/rate_limit.py`) rather than a token bucket: atomic on a single `INCR` (no Lua / no read-modify-write race), consistent with the codebase's two other limiters and their test harness, and it satisfies the "a burst is throttled" acceptance criterion. A token-bucket burst-carryover refinement is a possible follow-up.
- The **session cap** is a per-tenant *new-sessions-per-window* cap because MEHO holds no stateful MCP session store (`server.py::_issue_mcp_session_id`) — a precise concurrent-session count is unknowable without building a registry, which this task did not.
- Gate applies to **top-level** dispatches only: a composite's internal `dispatch_child` fan-out (`composite_depth_var > 0`) and approval-resumes (`_approved`) are exempt (avoids misattribution + self-deadlock).
- New doc `docs/codebase/rate-limiting.md`. `docs/codebase/mcp.md` tool table unchanged (chassis-level control, no new tool). No REST routes changed → no CLI OpenAPI snapshot regen.

## Out of scope / deferred
- `result_query` (the JSONFlux handle drill-in) is intentionally **not** separately rate-limited: it is a bounded read over the caller's own already-spilled, tenant+principal-isolated handle (low abuse value), it follows a `call_operation` that already consumed a rate token, and gating its pure query cores would couple them to full `Settings` construction. The higher-value discovery/execution paths are gated.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` (changed files) — clean
- [x] `mypy src/` — clean (the one pre-existing `socket.MSG_ERRQUEUE` error in `connectors/net/icmp.py` is a macOS-only quirk, green on Linux CI, unrelated to this change)
- [x] `pytest tests/test_dispatch_limits.py tests/test_mcp_session_limit.py tests/test_dispatcher_rate_limit_integration.py` — **28 passed** (window rollover / refill, over-limit retry-after, per-tenant override precedence, concurrency admit/reject/release, session cap, and the audit row on rejection proving no vendor traffic)
- [x] Regression sweep on touched areas — dispatcher / settings / preview / meta-tools / mcp server+initialize+audit / connector-read suites pass
- [x] `code-quality.py --diff` — 0 blockers

## Changelog (add under `[Unreleased]` at merge — not edited in this PR)
- Added: per-principal / per-tenant MCP dispatch rate limiting, per-principal concurrent-op cap, and a per-tenant new-MCP-session cap — all off by default, per-tenant configurable, over-limit events audited (#3500).

Closes #3500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
