### PR TITLE
fix(connectors): buffer raw wire bytes in the dispatch body cap so compressed vendor responses decode once

### DIFF
--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -416,11 +416,22 @@ async def _read_capped_json_response(
     same-origin redirect and destination-pinning transport behaviour is
     unchanged) and enforces a two-part cap: a ``Content-Length`` fast-reject
     up front, then a running byte total across
-    :meth:`~httpx.Response.aiter_bytes` chunks that aborts the moment the
+    :meth:`~httpx.Response.aiter_raw` chunks that aborts the moment the
     body would exceed :data:`_MAX_RESPONSE_BYTES`. At most the cap (plus one
     trailing chunk) is ever held in memory, and an over-cap body raises
     :exc:`ResponseTooLargeError` before :func:`json_payload_or_empty` can
     parse it.
+
+    The cap iterates :meth:`~httpx.Response.aiter_raw` — the raw wire bytes,
+    still carrying whatever ``Content-Encoding`` the vendor applied — rather
+    than :meth:`~httpx.Response.aiter_bytes`, which yields already-decoded
+    bytes. Buffering the raw bytes keeps them consistent with the retained
+    ``Content-Encoding`` header, so the re-materialised response decodes
+    exactly once on first access (a plaintext body under a ``gzip`` header
+    would otherwise make httpx attempt a second decode and raise
+    :exc:`httpx.DecodingError`). The running total therefore counts
+    compressed transfer bytes, matching the ``Content-Length`` fast-reject
+    above, which measures that same compressed length.
 
     An under-cap body is joined and re-materialised into a fully-read
     :class:`httpx.Response` carrying the original status, headers, request,
@@ -441,7 +452,7 @@ async def _read_capped_json_response(
         _reject_oversize_content_length(resp)
         chunks: list[bytes] = []
         total = 0
-        async for chunk in resp.aiter_bytes():
+        async for chunk in resp.aiter_raw():
             total += len(chunk)
             if total > _MAX_RESPONSE_BYTES:
                 raise ResponseTooLargeError(

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -53,11 +53,14 @@ Per-target base URL (evoila/meho#2873):
 from __future__ import annotations
 
 import datetime as _dt
+import gzip
+import json
 import socket as _socket
 import ssl
 import tempfile as _tempfile
 import threading as _threading
 import types
+import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from unittest.mock import patch
@@ -695,10 +698,9 @@ async def test_request_json_rejects_oversize_response_without_content_length(
 ) -> None:
     """An oversize body with no ``Content-Length`` is caught by the streamed total.
 
-    An absent (or understated / content-encoded) length header cannot smuggle
-    an oversize body past the guard: the running byte total across
-    ``aiter_bytes`` chunks aborts once the cap is exceeded, before the whole
-    body is buffered.
+    An absent (or understated) length header cannot smuggle an oversize body
+    past the guard: the running byte total across ``aiter_raw`` chunks aborts
+    once the cap is exceeded, before the whole body is buffered.
     """
     monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 1024)
     conn = _ConcreteHttpConnector()
@@ -814,6 +816,132 @@ async def test_post_json_under_cap_returns_parsed_payload(
         )
 
     assert result == {"value": "vm-42"}
+    await conn.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Content-encoded bodies decode exactly once through the byte cap
+# (regression guard for #3459 / fix #3521)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_json_gzip_encoded_response_decodes_once_regression_3459() -> None:
+    """A ``Content-Encoding: gzip`` GET body decodes once and parses (#3459 guard).
+
+    #3459 (the S09 body-size cap) buffered the cap loop's chunks from
+    :meth:`httpx.Response.aiter_bytes`, which yields **already-decoded** bytes,
+    then re-materialised the response with the plaintext body still under the
+    upstream ``Content-Encoding: gzip`` header — so httpx decoded a second time
+    on first content access and raised
+    ``httpx.DecodingError: Error -3 while decompressing data: incorrect header
+    check``. Every ingested/typed HTTP read of a compressing vendor broke.
+    This models a vCenter 8.x target behind an ingested ``vmware-rest``
+    connector that gzips its response; buffering the raw wire bytes
+    (:meth:`~httpx.Response.aiter_raw`) keeps them consistent with the retained
+    header, so the body decodes exactly once and parses.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    payload = {"value": [{"vm": "vm-101", "name": "web-01"}, {"vm": "vm-102"}]}
+    compressed = gzip.compress(json.dumps(payload).encode())
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.get("/api/inventory").respond(
+            200,
+            content=compressed,
+            headers={"content-type": "application/json", "content-encoding": "gzip"},
+        )
+        result = await conn._request_json(
+            target, "GET", "/api/inventory", operator=_make_operator("tok")
+        )
+
+    assert result == payload
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_json_gzip_encoded_response_decodes_once() -> None:
+    """The non-idempotent path also decodes a gzip body exactly once (#3459 guard)."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    payload = {"value": "session-token-shape"}
+    compressed = gzip.compress(json.dumps(payload).encode())
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.post("/api/sessions").respond(
+            200,
+            content=compressed,
+            headers={"content-type": "application/json", "content-encoding": "gzip"},
+        )
+        result = await conn._post_json(
+            target,
+            "/api/sessions",
+            operator=_make_operator("tok"),
+            json={"provider": "Local"},
+        )
+
+    assert result == payload
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_deflate_encoded_response_decodes_once() -> None:
+    """A ``Content-Encoding: deflate`` body decodes once and parses (#3459 guard)."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    payload = {"value": [{"id": "obj-1"}, {"id": "obj-2"}]}
+    compressed = zlib.compress(json.dumps(payload).encode())
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        mock.get("/api/items").respond(
+            200,
+            content=compressed,
+            headers={"content-type": "application/json", "content-encoding": "deflate"},
+        )
+        result = await conn._request_json(
+            target, "GET", "/api/items", operator=_make_operator("tok")
+        )
+
+    assert result == payload
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_json_rejects_oversize_compressed_body_by_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cap measures the compressed transfer length, not the decoded size.
+
+    The cap loop now counts raw wire bytes, matching the ``Content-Length``
+    fast-reject — both measure the compressed length the vendor actually put on
+    the wire. A gzip body whose *compressed* ``Content-Length`` exceeds the cap
+    is refused up front, and the rejection quotes that compressed length.
+    """
+    monkeypatch.setattr(http_adapter, "_MAX_RESPONSE_BYTES", 8)
+    conn = _ConcreteHttpConnector()
+    target = _make_target()
+
+    compressed = gzip.compress(json.dumps({"value": [1, 2, 3]}).encode())
+    assert len(compressed) > 8  # compressed length is what must trip the cap
+
+    async with respx.mock(base_url="https://vcenter.example.com") as mock:
+        route = mock.get("/api/inventory").respond(
+            200,
+            content=compressed,
+            headers={"content-type": "application/json", "content-encoding": "gzip"},
+        )
+        with pytest.raises(ResponseTooLargeError) as exc_info:
+            await conn._request_json(
+                target, "GET", "/api/inventory", operator=_make_operator("tok")
+            )
+
+    assert "Content-Length" in str(exc_info.value)
+    assert str(len(compressed)) in str(exc_info.value)
+    assert route.called
     await conn.aclose()
 
 


### PR DESCRIPTION
## Problem

Starting in v0.34.0, every `HttpConnector`-based read against a vendor that
returns a `gzip`- or `deflate`-encoded response fails with:

```
httpx.DecodingError: Error -3 while decompressing data: incorrect header check
```

This breaks all generic ingested connectors and typed HTTP connectors
(vmware-rest, vcf-fleet, gcloud, vcd, vra8, loki, harbor, the argocd HTTP
path) whenever the vendor compresses its response. Vault (hvac, not an
`HttpConnector`) is unaffected. Reproduced live against a vCenter 8.x target
behind an ingested `vmware-rest` connector, and locally against httpx 0.28.1.

## Root cause

PR #3459 (the S09 body-size cap) introduced `_read_capped_json_response` in
`backend/src/meho_backplane/connectors/adapters/http.py`. Its cap loop
collected chunks via `resp.aiter_bytes()` — which yields **already-decompressed**
bytes — then rebuilt the response with:

```python
httpx.Response(status_code=..., headers=resp.headers, content=b"".join(chunks), ...)
```

keeping the upstream `Content-Encoding: gzip` header over a now-plaintext body.
httpx then attempts to decode a **second** time on first content access
(`resp.content` / `resp.json()`) → zlib `-3`. Both `_request_json` and
`_post_json` route through this helper, so every compressed vendor read broke.

## Fix

Iterate `resp.aiter_raw()` in the cap loop instead of `resp.aiter_bytes()`. The
buffered content is then the raw wire bytes that match the retained
`Content-Encoding` header, so the re-materialised response decodes exactly once
— byte-identical to the pre-#3459 `client.request()` path.

Cap semantics are preserved and made internally consistent: the running total
now counts **compressed** transfer bytes, matching the existing
`Content-Length` fast-reject (`_reject_oversize_content_length`), which already
measured the compressed length. No headers are stripped, no feature flag is
added, and the SSRF/destination-pinning transport is untouched. Docstrings on
the helper and the affected test updated to reflect `aiter_raw`.

## Tests

`backend/tests/test_connectors_http_adapter.py`, using the existing respx/httpx
fixture style:

- `test_request_json_gzip_encoded_response_decodes_once_regression_3459` — a
  `Content-Encoding: gzip` body (`gzip.compress(json)`) parses correctly through
  `_request_json` (the named regression guard for #3459).
- `test_post_json_gzip_encoded_response_decodes_once` — same via `_post_json`.
- `test_request_json_deflate_encoded_response_decodes_once` — a `deflate`
  (`zlib.compress`) body parses.
- `test_request_json_rejects_oversize_compressed_body_by_content_length` — the
  cap still rejects an oversize compressed body by its (compressed)
  `Content-Length` and quotes that compressed length.
- The oversize-streamed-body-without-`Content-Length` rejection and the plain
  (identity) under-cap parse remain covered by the pre-existing
  `test_request_json_rejects_oversize_response_without_content_length` and
  `test_{request,post}_json_under_cap_returns_parsed_payload` tests (docstring of
  the former updated from `aiter_bytes` to `aiter_raw`).

Commands (run from `backend/`, as CI does):

- `uv run pytest tests/test_connectors_http_adapter.py` → **99 passed** (was 95; +4).
- Full backend unit suite (`find tests -name 'test_*.py' -not -path 'tests/integration/*' -not -path 'tests/migrations/*'`, `uv run pytest -n auto --dist loadscope`) — green.
- `uv run ruff check src/ tests/` → clean; `uv run ruff format --check src/ tests/` → clean; `uv run mypy src/` → clean for the touched file.

## CHANGELOG entry (for the roll PR)

```
### Fixed
- Compressed (`gzip`/`deflate`) vendor responses no longer fail with `httpx.DecodingError` ("incorrect header check"): the dispatch body-size cap (#3459) now buffers raw wire bytes so the body decodes exactly once, restoring the pre-cap behaviour for every HttpConnector read. (#3521)
```

Closes #3521

🤖 Generated with [Claude Code](https://claude.com/claude-code)