### PR TITLE
fix(ui): structure scheduler create-trigger modal + fix timezone re-validation (#335)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/scheduler/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/scheduler/_create_modal.html
@@ -22,11 +22,11 @@
   kind's discriminator field is meaningful; the server populates only that
   field on the wire schema regardless of any stale hidden values.
 
-  Live cron validation: the cron <input> ``hx-post``s to
-  ``/ui/scheduler/validate-cron`` (debounced) and swaps the
-  ``#scheduler-cron-preview`` fragment, so the operator sees validity + a
-  ``next_fire_at`` preview before submit -- no free-text cron with no
-  feedback.
+  Live cron validation: the cron <input> (debounced) and the timezone
+  <input> (on change) each ``hx-post`` to ``/ui/scheduler/validate-cron``
+  and swap the ``#scheduler-cron-preview`` fragment, so the operator sees
+  validity + a ``next_fire_at`` preview before submit -- no free-text cron
+  with no feedback, and no stale preview after a timezone edit (#335).
 
   CSRF: the form carries its own ``hx-headers`` echo of the token (HTMX
   does not inherit ``hx-headers`` to children injected into a swapped
@@ -65,11 +65,11 @@
       x-data="{ kind: 'cron' }"
     >
       {# ---------- Agent definition ---------- #}
-      <label class="form-control">
-        <span class="label-text">Agent definition</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Agent definition</span>
         <select
           name="agent_definition_id"
-          class="select select-bordered select-sm"
+          class="select select-bordered select-sm w-full"
           required
           aria-label="Agent definition"
         >
@@ -83,11 +83,11 @@
       </label>
 
       {# ---------- Kind switch ---------- #}
-      <label class="form-control">
-        <span class="label-text">Kind</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Kind</span>
         <select
           name="kind"
-          class="select select-bordered select-sm"
+          class="select select-bordered select-sm w-full"
           x-model="kind"
           aria-label="Trigger kind"
         >
@@ -99,31 +99,41 @@
 
       {# ---------- cron fields ---------- #}
       <div x-show="kind === 'cron'" class="space-y-2 rounded-box border border-base-300 p-3">
-        <label class="form-control">
-          <span class="label-text">Cron expression (5-field)</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Cron expression (5-field)</span>
           <input
             type="text"
             name="cron_expr"
-            class="input input-bordered input-sm font-mono"
+            class="input input-bordered input-sm font-mono w-full"
             placeholder="*/15 * * * *"
             maxlength="128"
             hx-post="/ui/scheduler/validate-cron"
-            hx-trigger="input changed delay:400ms, change from:find input[name=timezone]"
+            hx-trigger="input changed delay:400ms"
             hx-target="#scheduler-cron-preview"
             hx-swap="innerHTML"
             hx-include="closest div"
             aria-label="Cron expression"
           />
         </label>
-        <label class="form-control">
-          <span class="label-text">Timezone (IANA)</span>
+        {# The timezone input carries its own validate-cron wiring: htmx's
+           ``from:find`` searches descendants of the element the trigger is
+           declared on, so a ``change from:find input[name=timezone]`` clause
+           on the (childless) cron <input> never bound and a timezone edit
+           silently kept a stale next-fire preview (#335). #}
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Timezone (IANA)</span>
           <input
             type="text"
             name="timezone"
-            class="input input-bordered input-sm"
+            class="input input-bordered input-sm w-full"
             value="UTC"
             maxlength="64"
             placeholder="UTC"
+            hx-post="/ui/scheduler/validate-cron"
+            hx-trigger="change"
+            hx-target="#scheduler-cron-preview"
+            hx-swap="innerHTML"
+            hx-include="closest div"
             aria-label="Timezone"
           />
         </label>
@@ -141,19 +151,19 @@
          browser's own DST-aware ``Date``; the live hint shows the resolved
          UTC so the conversion is visible, not silent (#2339). #}
       <div x-show="kind === 'one_off'" x-cloak class="space-y-2 rounded-box border border-base-300 p-3">
-        <label class="form-control">
-          <span class="label-text">Fire at (your local time)</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Fire at <span class="opacity-60 font-normal">(your local time)</span></span>
           <input
             type="datetime-local"
             name="fire_at"
-            class="input input-bordered input-sm"
+            class="input input-bordered input-sm w-full"
             data-fire-at
             aria-label="Fire at"
             aria-describedby="scheduler-fire-at-hint"
           />
           <span
             id="scheduler-fire-at-hint"
-            class="label-text-alt opacity-60"
+            class="text-xs opacity-60"
             data-fire-at-hint
             aria-live="polite"
           >Enter your local wall-clock time — it is converted to UTC on submit.</span>
@@ -162,11 +172,11 @@
 
       {# ---------- event fields ---------- #}
       <div x-show="kind === 'event'" x-cloak class="space-y-2 rounded-box border border-base-300 p-3">
-        <label class="form-control">
-          <span class="label-text">Event filter (JSON object)</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Event filter <span class="opacity-60 font-normal">(JSON object)</span></span>
           <textarea
             name="event_filter"
-            class="textarea textarea-bordered textarea-sm font-mono"
+            class="textarea textarea-bordered textarea-sm font-mono w-full"
             rows="3"
             placeholder='{"type": "connector.fingerprint.changed"}'
             aria-label="Event filter"
@@ -179,28 +189,28 @@
          source, so an input-less trigger fails every fire) and optional for
          event (its future dispatch junction may derive the prompt from the
          matched event). The label tracks the Alpine kind-switch. #}
-      <label class="form-control">
-        <span class="label-text">
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">
           Run inputs (JSON object)<span
-            class="opacity-60"
+            class="opacity-60 font-normal"
             x-show="kind !== 'event'"
           > — required, must render a prompt</span><span
-            class="opacity-60"
+            class="opacity-60 font-normal"
             x-cloak
             x-show="kind === 'event'"
           > — optional</span>
         </span>
         <textarea
           name="inputs"
-          class="textarea textarea-bordered textarea-sm font-mono"
+          class="textarea textarea-bordered textarea-sm font-mono w-full"
           rows="2"
           placeholder='{"prompt": "summarise overnight alerts"}'
           aria-label="Run inputs"
         ></textarea>
       </label>
 
-      <fieldset class="form-control">
-        <legend class="label-text mb-1">In-flight policy</legend>
+      <fieldset>
+        <legend class="text-sm font-medium mb-1">In-flight policy</legend>
         <div class="flex flex-col gap-1">
           {% for policy in in_flight_policy_values %}
             <label class="flex items-center gap-2 text-sm">
@@ -217,12 +227,12 @@
         </div>
       </fieldset>
 
-      <label class="form-control">
-        <span class="label-text">Change ticket (work_ref, optional)</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Change ticket <span class="opacity-60 font-normal">(work_ref, optional)</span></span>
         <input
           type="text"
           name="work_ref"
-          class="input input-bordered input-sm font-mono"
+          class="input input-bordered input-sm font-mono w-full"
           placeholder="gh:evoila/meho#1826"
           maxlength="256"
           aria-label="Change ticket reference"

--- a/backend/tests/test_ui_scheduler.py
+++ b/backend/tests/test_ui_scheduler.py
@@ -587,6 +587,18 @@ def test_create_modal_renders_for_tenant_admin() -> None:
     # disinherited so the descendant validate-cron POST does not inherit it
     # and log `... returned no matches!` on every debounced keystroke.
     assert 'hx-disinherit="hx-disabled-elt"' in body
+    # #335: daisyUI v5 removed `form-control` / `label-text` /
+    # `label-text-alt` (zero compiled rules) — the modal must use the
+    # migrated flex-column label pattern instead.
+    assert "form-control" not in body
+    assert "label-text" not in body
+    # #335: a timezone edit must re-validate the cron preview. htmx's
+    # `from:find` searches descendants of the element the trigger sits on,
+    # so the old `change from:find input[name=timezone]` clause on the
+    # (childless) cron input never bound; the timezone input now carries
+    # its own validate-cron wiring.
+    assert "from:find" not in body
+    assert body.count('hx-post="/ui/scheduler/validate-cron"') == 2
 
 
 def test_create_modal_carries_fire_at_utc_conversion() -> None:


### PR DESCRIPTION
## Summary

- Migrates the Scheduler create-trigger modal (`scheduler/_create_modal.html`) off the daisyUI v4 dead classes (`form-control` / `label-text` / `label-text-alt` — zero compiled rules in v5) to the established pattern: `flex flex-col gap-1` label wrappers, `text-sm font-medium` labels, hints as `text-xs opacity-60`, `w-full` controls, inline qualifiers as `opacity-60 font-normal` spans.
- Fixes a dead htmx binding: `change from:find input[name=timezone]` on the cron input never bound (`from:find` searches descendants of the element carrying the trigger, and an `<input>` has none), so editing the timezone silently kept a stale `next_fire_at` preview. The timezone input now carries its own `hx-post="/ui/scheduler/validate-cron"` wiring (`hx-trigger="change"`, same target/include) — same bug class and fix shape as the broadcast filter bar (#3072).
- Untouched: Alpine `x-data` kind switch, the `data-fire-at` local→UTC conversion script (#2339), form-level CSRF `hx-headers`, `hx-disabled-elt`/`hx-disinherit`, `data-action` hooks.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `pytest tests/test_ui_scheduler.py` — 32 passed
- [x] Render guards added to `test_create_modal_renders_for_tenant_admin`: no `form-control` / `label-text` / `from:find` in the rendered modal; exactly 2 `validate-cron` posts wired (cron input + timezone input)
- [x] `grep -n "form-control\|label-text" scheduler/_create_modal.html` — clean

## References

Task: Closes evoila-bosnia/meho-internal#335 (parent initiative: evoila-bosnia/meho-internal#337, round 8 — Scheduler; sibling: evoila-bosnia/meho-internal#336). Cross-repo `Closes` does not auto-close — close #335 manually on merge.

Precedent migrations: #2906, #3108, #3309; precedent `from:find` fix: #3072.
