### PR TITLE
fix(ui): humanize scheduler detail-view timestamps (#336)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/scheduler/detail.html
+++ b/backend/src/meho_backplane/ui/templates/scheduler/detail.html
@@ -11,6 +11,14 @@
 
   The cancel button (tenant_admin-only, hidden on a terminal trigger)
   HTMX-loads the terminal-confirm dialog into the modal container.
+
+  Timestamps follow the console-wide ``<time>`` convention (precedent
+  ``topology/_drawer.html``): the machine-readable ISO instant lives in
+  the ``datetime`` attribute, the visible text is
+  ``YYYY-MM-DD HH:MM UTC`` (#336). Every instant reaching this template
+  has already passed through ``coerce_utc_aware`` in the handler, so the
+  "UTC" suffix is accurate on both the PostgreSQL (tz-aware) and SQLite
+  (naive round-trip) paths.
 -#}
 {% extends "base.html" %}
 
@@ -66,7 +74,7 @@
             <dd>{{ trigger.timezone }}</dd>
           {% elif trigger.kind == "one_off" %}
             <dt class="opacity-60">Fire at</dt>
-            <dd class="font-mono">{% if trigger.fire_at %}{{ trigger.fire_at.isoformat() }}{% else %}—{% endif %}</dd>
+            <dd>{% if trigger.fire_at %}<time datetime="{{ trigger.fire_at.isoformat() }}">{{ trigger.fire_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>{% else %}—{% endif %}</dd>
           {% else %}
             <dt class="opacity-60">Event filter</dt>
             <dd>
@@ -79,10 +87,10 @@
           {% endif %}
 
           <dt class="opacity-60">Next fire</dt>
-          <dd class="font-mono">{% if trigger.next_fire_at %}{{ trigger.next_fire_at.isoformat() }}{% else %}<span class="opacity-40">— (no future fire)</span>{% endif %}</dd>
+          <dd>{% if trigger.next_fire_at %}<time datetime="{{ trigger.next_fire_at.isoformat() }}">{{ trigger.next_fire_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>{% else %}<span class="opacity-40">— (no future fire)</span>{% endif %}</dd>
 
           <dt class="opacity-60">Last fired</dt>
-          <dd class="font-mono">{% if trigger.last_fired_at %}{{ trigger.last_fired_at.isoformat() }}{% else %}<span class="opacity-40">— (never)</span>{% endif %}</dd>
+          <dd>{% if trigger.last_fired_at %}<time datetime="{{ trigger.last_fired_at.isoformat() }}">{{ trigger.last_fired_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>{% else %}<span class="opacity-40">— (never)</span>{% endif %}</dd>
 
           {# Skip state (#2327): a non-zero skip_count means the scheduler
              is skipping this trigger every tick without firing it. Shown
@@ -97,7 +105,7 @@
             <dt class="opacity-60">Skip reason</dt>
             <dd class="font-mono text-xs">{{ trigger.last_skip_reason or "—" }}</dd>
             <dt class="opacity-60">Last skipped</dt>
-            <dd class="font-mono text-xs">{% if trigger.last_skipped_at %}{{ trigger.last_skipped_at.isoformat() }}{% else %}<span class="opacity-40">—</span>{% endif %}</dd>
+            <dd class="text-xs">{% if trigger.last_skipped_at %}<time datetime="{{ trigger.last_skipped_at.isoformat() }}">{{ trigger.last_skipped_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>{% else %}<span class="opacity-40">—</span>{% endif %}</dd>
           {% elif trigger.last_skip_reason %}
             {# skip_count reset to 0 by a later fire, but the last cause is
                retained on a parked row -- keep the reason visible. #}
@@ -144,9 +152,9 @@
           </dd>
 
           <dt class="opacity-60">Created</dt>
-          <dd class="font-mono text-xs">{% if trigger.created_at %}{{ trigger.created_at.isoformat() }}{% endif %}</dd>
+          <dd class="text-xs">{% if trigger.created_at %}<time datetime="{{ trigger.created_at.isoformat() }}">{{ trigger.created_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>{% endif %}</dd>
           <dt class="opacity-60">Updated</dt>
-          <dd class="font-mono text-xs">{% if trigger.updated_at %}{{ trigger.updated_at.isoformat() }}{% endif %}</dd>
+          <dd class="text-xs">{% if trigger.updated_at %}<time datetime="{{ trigger.updated_at.isoformat() }}">{{ trigger.updated_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>{% endif %}</dd>
         </dl>
       </div>
     </div>

--- a/backend/tests/test_ui_scheduler.py
+++ b/backend/tests/test_ui_scheduler.py
@@ -184,6 +184,10 @@ def _seed_trigger(
     status_value: str = ScheduledTriggerStatus.ACTIVE.value,
     next_fire_at: datetime | None = None,
     work_ref: str | None = None,
+    last_fired_at: datetime | None = None,
+    skip_count: int = 0,
+    last_skip_reason: str | None = None,
+    last_skipped_at: datetime | None = None,
 ) -> uuid.UUID:
     tid = trigger_id or uuid.uuid4()
     now = datetime.now(UTC)
@@ -204,7 +208,10 @@ def _seed_trigger(
                     status=status_value,
                     in_flight_policy=ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT.value,
                     next_fire_at=next_fire_at or (now + timedelta(hours=1)),
-                    last_fired_at=None,
+                    last_fired_at=last_fired_at,
+                    skip_count=skip_count,
+                    last_skip_reason=last_skip_reason,
+                    last_skipped_at=last_skipped_at,
                     inputs={"prompt": "summarise"},
                     identity_sub="__scheduler__",
                     created_by_sub=_OP_ADMIN,
@@ -526,6 +533,59 @@ def test_detail_renders_full_row_for_operator() -> None:
     assert "__scheduler__" in body  # identity_sub
     assert "fail_into_audit" in body  # in_flight_policy
     assert "gh:evoila/meho#1826" in body  # work_ref chip + recent-fires link
+    # #336: timestamps follow the console `<time>` convention -- a
+    # machine-readable ISO instant in the attribute, a human-readable
+    # `YYYY-MM-DD HH:MM UTC` string as the visible text. The raw
+    # microsecond isoformat must no longer be the element's text, which a
+    # bare `+00:00</` (isoformat immediately followed by a closing tag)
+    # would betray.
+    assert "<time datetime=" in body
+    assert "UTC</time>" in body
+    assert "+00:00</" not in body
+    # The never-fired fallback survives the humanisation.
+    assert "(never)" in body
+
+
+def test_detail_humanises_one_off_and_skip_timestamps() -> None:
+    """The one_off / last-fired / last-skipped instants humanise too (#336).
+
+    The default cron fixture never populates ``fire_at``, ``last_fired_at``
+    or ``last_skipped_at``, so those three of the page's six timestamps
+    would go unexercised. Seeding a skipping one_off trigger renders every
+    remaining branch and pins the exact ``YYYY-MM-DD HH:MM UTC`` shape.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A)
+    fire_at = datetime(2026, 6, 18, 9, 30, 12, 483920, tzinfo=UTC)
+    last_fired = datetime(2026, 6, 17, 22, 5, 1, 12345, tzinfo=UTC)
+    last_skipped = datetime(2026, 6, 18, 8, 0, 44, 900001, tzinfo=UTC)
+    tid = _seed_trigger(
+        tenant_id=_TENANT_A,
+        kind=ScheduledTriggerKind.ONE_OFF.value,
+        cron_expr=None,
+        fire_at=fire_at,
+        last_fired_at=last_fired,
+        skip_count=2,
+        last_skip_reason="previous run still in flight",
+        last_skipped_at=last_skipped,
+    )
+    client, mock, _ = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    try:
+        response = client.get(f"/ui/scheduler/{tid}")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "2026-06-18 09:30 UTC</time>" in body  # fire_at
+    assert "2026-06-17 22:05 UTC</time>" in body  # last_fired_at
+    assert "2026-06-18 08:00 UTC</time>" in body  # last_skipped_at
+    # The ISO instant stays machine-readable in the attribute.
+    assert f'datetime="{fire_at.isoformat()}"' in body
+    # Microsecond precision never reaches the visible text.
+    assert "483920" not in body.replace(fire_at.isoformat(), "")
+    assert "+00:00</" not in body
 
 
 def test_detail_cross_tenant_is_404() -> None:


### PR DESCRIPTION
## Summary

- The scheduler detail page rendered all six of its instants as raw `isoformat()` output (`2026-06-18T09:30:12.483920+00:00`) — hard to scan and inconsistent with the rest of the console. All six now follow the established `<time>` convention (precedent `topology/_drawer.html:178`, broadcast drawer #3107): the ISO instant stays machine-readable in the `datetime` attribute, the visible text is `YYYY-MM-DD HH:MM UTC`.
- The **"UTC" label is verified, not assumed**: every one of these six values already passes through `coerce_utc_aware()` in `_build_context` ([detail.py:122–140](https://github.com/evoila/meho/blob/main/backend/src/meho_backplane/ui/routes/scheduler/detail.py#L122-L140)), so the suffix is accurate on both the PostgreSQL tz-aware path and the SQLite naive round-trip.
- `font-mono` dropped from the humanized cells (the formatted string is no longer a machine literal), kept on genuinely machine-shaped values — cron expression, ids, subs, work_ref. Empty states (`—`, `— (never)`, `— (no future fire)`) unchanged.
- The existing fixture only populated three of the six timestamps, so `_seed_trigger` grew optional fired/skip parameters and a new test renders a skipping `one_off` trigger to cover the other three.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `pytest tests/test_ui_scheduler.py tests/test_ui_scheduler_views.py` — **43 passed** (42 before, +1 new)
- [x] All six timestamps humanized — `fire_at`, `next_fire_at`, `last_fired_at`, `last_skipped_at`, `created_at`, `updated_at`; the three previously-unexercised ones are pinned to exact strings (`2026-06-18 09:30 UTC</time>` etc.) by the new test
- [x] Empty-state fallbacks preserved — `assert "(never)" in body`
- [x] No raw isoformat as visible text — `assert "+00:00</" not in body` (the ISO instant may only appear inside a `datetime` attribute); microsecond precision asserted absent from the visible text
- [x] `grep isoformat detail.html` — all six occurrences are inside `datetime="…"` attributes

## Out of scope

- Sibling task evoila-bosnia/meho-internal#335 (create-trigger modal form layout + timezone re-validation) — PR #3527.
- `coerce_utc_aware` passes an already-aware non-UTC datetime through unchanged rather than converting it. Not reachable today (the driver returns UTC), and the pre-existing contract is pinned by `test_coerce_utc_aware_passes_aware_through` — noted, not changed.

## References

Closes https://github.com/evoila-bosnia/meho-internal/issues/336

Parent initiative: evoila-bosnia/meho-internal#337 (round 8 — Scheduler).
