### PR TITLE
fix(connectors): retry pfsense.gateway.delete once when a playback does not persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ connector-related release-notes line.
 
 ### Fixed
 
-- `pfsense.gateway.delete` now retries its `pfSsh.php` apply once and re-verifies before failing closed. A transient pfSense-runtime persistence race could leave `write_config()` uncommitted even though the playback exited `0`, so an unreferenced gateway that would otherwise delete cleanly was left in place and the teardown hard-failed with no recovery. The idempotent delete fragment (it re-matches the gateway by name) is now re-applied once to recover the transient non-persist; only a still-failing read-back raises, and the diagnostic distinguishes a non-persisting write from a reference-guard refusal. Distinct from the reference-guard completeness gap tracked separately in #3315. (#3529)
+- `pfsense.gateway.delete` now retries its `pfSsh.php` apply once and re-verifies before failing closed. A transient pfSense-runtime persistence race could leave `write_config()` uncommitted even though the playback exited `0`, so an unreferenced gateway that would otherwise delete cleanly was left in place and the teardown hard-failed with no recovery. The idempotent delete fragment (it re-matches the gateway by name) is now re-applied once to recover the transient non-persist; only a still-failing read-back raises, and the diagnostic distinguishes a non-persisting write from a reference-guard refusal. Distinct from the reference-guard completeness gap tracked separately in #3315. (#3529 / #3530)
 
 ## [0.34.1] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- `pfsense.gateway.delete` now retries its `pfSsh.php` apply once and re-verifies before failing closed. A transient pfSense-runtime persistence race could leave `write_config()` uncommitted even though the playback exited `0`, so an unreferenced gateway that would otherwise delete cleanly was left in place and the teardown hard-failed with no recovery. The idempotent delete fragment (it re-matches the gateway by name) is now re-applied once to recover the transient non-persist; only a still-failing read-back raises, and the diagnostic distinguishes a non-persisting write from a reference-guard refusal. Distinct from the reference-guard completeness gap tracked separately in #3315. (#3529)
+
 ## [0.34.1] - 2026-09-09
 
 ### Fixed

--- a/backend/src/meho_backplane/connectors/pfsense/ops_delete.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_delete.py
@@ -1160,24 +1160,45 @@ async def pfsense_gateway_delete(
         }
 
     gateway = matches[0]
-    await _apply_playback(
-        self,
-        target,
-        script_name=f"meho_gateway_delete_{_script_token(name)}",
-        script_body=_build_gateway_delete_playback(name),
-        operator=operator,
-    )
+    script_name = f"meho_gateway_delete_{_script_token(name)}"
+    script_body = _build_gateway_delete_playback(name)
 
-    after = await _read_config_xml(self, target, operator)
-    gateways_after = parse_gateways_xml(after)
-    still_present = any(g.get("name") == name for g in gateways_after)
-    removed_exactly_one = len(gateways_after) == len(gateways_before) - 1
-    if still_present or not removed_exactly_one:
-        raise RuntimeError(
-            f"gateway.delete verification failed for {name!r}: present_after={still_present}, "
-            f"gateways {len(gateways_before)}->{len(gateways_after)} (expected exactly one "
-            "fewer); the pfSsh.php playback did not persist a clean single-gateway delete"
+    # A ``pfSsh.php playback`` exits 0 even when ``write_config()`` never
+    # committed: a transient pfSense-runtime persistence race (a concurrent
+    # config-write / gateway event re-serialising an in-memory ``$config``
+    # snapshot that still carried the gateway) can leave config.xml untouched
+    # (#3529 -- observed on an unreferenced gateway whose delete would
+    # otherwise apply cleanly). The single-shot ``_apply_playback`` cannot see
+    # this; only the read-back below can. The delete fragment is idempotent (it
+    # re-matches the gateway by name and persists only on a single removal), so
+    # a non-persisting read-back is retried once and re-verified before we fail
+    # closed. (The referenced-guard completeness gap in
+    # ``find_gateway_references`` is a distinct latent defect tracked in #3315,
+    # not addressed here.)
+    max_attempts = 2
+    for attempt in range(1, max_attempts + 1):
+        await _apply_playback(
+            self,
+            target,
+            script_name=script_name,
+            script_body=script_body,
+            operator=operator,
         )
+        after = await _read_config_xml(self, target, operator)
+        gateways_after = parse_gateways_xml(after)
+        still_present = any(g.get("name") == name for g in gateways_after)
+        removed_exactly_one = len(gateways_after) == len(gateways_before) - 1
+        if not still_present and removed_exactly_one:
+            break
+        if attempt >= max_attempts:
+            raise RuntimeError(
+                f"gateway.delete verification failed for {name!r} after {attempt} "
+                f"apply attempt(s): present_after={still_present}, gateways "
+                f"{len(gateways_before)}->{len(gateways_after)} (expected exactly one "
+                "fewer); the pfSsh.php playback did not persist a clean single-gateway "
+                "delete"
+            )
+
     return {
         **result,
         "status": "deleted",

--- a/backend/tests/test_connectors_pfsense_teardown_ops.py
+++ b/backend/tests/test_connectors_pfsense_teardown_ops.py
@@ -485,18 +485,59 @@ async def test_gateway_delete_ambiguous_refuses_fail_closed() -> None:
     assert mock_cmd.await_count == 1
 
 
-async def test_gateway_delete_verification_failure_raises() -> None:
+async def test_gateway_delete_verification_failure_raises_after_retry() -> None:
+    """Both the first apply AND the retry fail to persist -> the op raises the
+    verification diagnostic, having attempted the playback twice (#3529)."""
     connector = PfSenseConnector()
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.side_effect = [
             _proc(_CONFIG_ROUTING),  # guard read
-            _proc("", 0),  # stage
-            _proc("", 0),  # playback
-            _proc("", 0),  # rm
-            _proc(_CONFIG_ROUTING),  # read-back: gateway still present
+            _proc("", 0),  # attempt 1: stage
+            _proc("", 0),  # attempt 1: playback
+            _proc("", 0),  # attempt 1: rm
+            _proc(_CONFIG_ROUTING),  # attempt 1 read-back: gateway still present
+            _proc("", 0),  # attempt 2 (retry): stage
+            _proc("", 0),  # attempt 2 (retry): playback
+            _proc("", 0),  # attempt 2 (retry): rm
+            _proc(_CONFIG_ROUTING),  # attempt 2 read-back: STILL present -> fail closed
         ]
-        with pytest.raises(RuntimeError, match="verification failed"):
+        with pytest.raises(RuntimeError, match="did not persist a clean single-gateway delete"):
             await connector.gateway_delete(None, {"name": "RETIRING_GW"})
+    # The retry was attempted: the playback ran exactly twice before raising.
+    playbacks = [c for c in _cmds(mock_cmd) if c.startswith("pfSsh.php playback")]
+    assert len(playbacks) == 2
+
+
+async def test_gateway_delete_retries_once_then_persists() -> None:
+    """A first playback that did not persist (read-back still shows the gateway)
+    is retried once; the retry persists and the op succeeds (#3529).
+
+    Models the observed pfSense-runtime persistence race: ``pfSsh.php playback``
+    exits 0 but ``write_config()`` did not commit, so the first read-back still
+    carries the gateway; the idempotent retry then removes it cleanly.
+    """
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_ROUTING),  # guard read (2 gateways)
+            _proc("", 0),  # attempt 1: stage
+            _proc("", 0),  # attempt 1: playback (exit 0 but did not persist)
+            _proc("", 0),  # attempt 1: rm
+            _proc(_CONFIG_ROUTING),  # attempt 1 read-back: gateway STILL present
+            _proc("", 0),  # attempt 2 (retry): stage
+            _proc("", 0),  # attempt 2 (retry): playback
+            _proc("", 0),  # attempt 2 (retry): rm
+            _proc(_CONFIG_ROUTING_NO_RETIRING_GW),  # attempt 2 read-back: gone
+        ]
+        result = await connector.gateway_delete(None, {"name": "RETIRING_GW"})
+    assert result["status"] == "deleted"
+    assert result["verified"] is True
+    assert result["gateways_before"] == 2
+    assert result["gateways_after"] == 1
+    assert result["removed"]["name"] == "RETIRING_GW"
+    # The apply/playback was invoked TWICE: once (non-persisting) then the retry.
+    playbacks = [c for c in _cmds(mock_cmd) if c.startswith("pfSsh.php playback")]
+    assert len(playbacks) == 2
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

`pfsense.gateway.delete` now retries its `pfSsh.php` apply **once** and re-verifies before failing closed.

## Why

An **unreferenced** gateway could fail to delete because the delete's playback exited `0` while `write_config()` never committed — a transient pfSense-runtime persistence race re-serialising an in-memory `$config` snapshot that still carried the gateway. The single-shot `_apply_playback` cannot detect a non-persisting write (playback exits `0` even when it writes nothing); only the handler's config.xml read-back does, and it had **no recovery step**. A transient non-persist therefore turned into a hard teardown failure needing manual cleanup.

Field evidence (see #3529): the same target's sibling `pfsense.route.static.delete` succeeded in the same run over the identical apply path, and the gateway-delete PHP fragment is byte-structurally identical to the working route fragment — so this is not fragment logic, it is a runtime persistence race.

## How

In `pfsense_gateway_delete`, the apply + read-back is wrapped in a bounded 2-attempt loop. The delete fragment is idempotent (it re-matches the gateway by name and persists only on a single removal), so on a non-persisting read-back it is safely re-applied once and re-verified. Only a still-failing second read-back raises the existing `RuntimeError` diagnostic — enriched to report how many apply attempts were made, and still distinguishing a non-persisting `write_config()` from a reference-guard refusal.

Blast radius is confined to the gateway-delete path: `_apply_playback`'s single-shot contract is unchanged for every other caller (route/alias/nat deletes, adds).

## Tests

- `test_gateway_delete_retries_once_then_persists` — first apply does not persist (read-back still shows the gateway), the retry persists (read-back shows it gone) → op succeeds; asserts the playback was invoked **twice**.
- `test_gateway_delete_verification_failure_raises_after_retry` — both attempts fail to persist → op raises the verification diagnostic; asserts the playback was invoked **twice** (retry attempted) before raising.

Local results (backend): `test_connectors_pfsense_teardown_ops.py` 52 passed; the other three pfSense suites (`delete_ops`, `ops`, `e2e`) 184 passed. `ruff check` + `ruff format --check` clean over `src/`+`tests/`; `mypy` clean on the changed source.

## Not in scope

The reference-guard completeness gap in `find_gateway_references` (it does not scan `<filter><rule><gateway>` or `<interfaces>/<optN>/<gateway>`) is a **distinct** latent defect tracked in #3315 — not the cause here (the guard was correctly empty) and not touched.

Closes #3529

🤖 Generated with [Claude Code](https://claude.com/claude-code)