### PR TITLE
docs(changelog): roll [Unreleased] into 0.34.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.34.2] - 2026-09-10
+
 ### Fixed
 
 - `pfsense.gateway.delete` now retries its `pfSsh.php` apply once and re-verifies before failing closed. A transient pfSense-runtime persistence race could leave `write_config()` uncommitted even though the playback exited `0`, so an unreferenced gateway that would otherwise delete cleanly was left in place and the teardown hard-failed with no recovery. The idempotent delete fragment (it re-matches the gateway by name) is now re-applied once to recover the transient non-persist; only a still-failing read-back raises, and the diagnostic distinguishes a non-persisting write from a reference-guard refusal. Distinct from the reference-guard completeness gap tracked separately in #3315. (#3529 / #3530)


### PR DESCRIPTION
## What

Release prep for **v0.34.2** (tag-driven patch). Rolls the single
`[Unreleased]` entry — the `pfsense.gateway.delete` transient-non-persist
retry (#3529 / #3530) — into a new dated `## [0.34.2] - 2026-09-10`
section, leaving a fresh empty `[Unreleased]`. CHANGELOG / release-notes
detail only; **no code, no `Chart.yaml`/appVersion bump** (the git tag
stays the sole version source, per `docs/RELEASING.md`).

## Scope note — the published `[0.34.1]` section is intentionally kept

This differs from the brief I was handed, which assumed v0.34.1 was a
"cut-but-unrolled" tag being superseded and that **both** #3526 and #3530
sat under `[Unreleased]`. Verified against the repo, that premise does not
hold:

- **v0.34.1 is a fully published release.** The annotated tag `v0.34.1` is
  on `origin` (→ `b051a2e0`, the #3526 CVE-bump commit), a **non-draft**
  GitHub Release exists (published 2026-09-09) with the complete rolled
  notes + all signed CLI assets, and the multi-arch image
  `ghcr.io/evoila/meho:v0.34.1` published (index `sha256:971c8889…`,
  amd64 + arm64 + attestations).
- On `origin/main`, `[Unreleased]` held **only** #3530. #3526 already sits
  correctly under the published `[0.34.1]` section.

Folding `[0.34.1]` into `[0.34.2]` would erase the changelog record of a
real published release and desync it from the releases page. So the
correct, Keep-a-Changelog-hygienic roll (matching #3525) is: keep
`[0.34.1]`, and `[0.34.2]` carries exactly what is new in v0.34.2 over
v0.34.1 — the #3530 fix. v0.34.2's **code** still carries all of v0.34.1's
content (it is a superset commit) plus #3530.

The `cli-release.yml` awk extractor was simulated against this file: the
`## [0.34.2]` section resolves to the #3530 entry (non-empty release
notes), `[Unreleased]` is empty, `[0.34.1]` is intact.

## Post-merge

Do **not** tag until this lands on `main` with a green run. The v0.34.2
tag must point at this PR's merge commit so the auto-published GitHub
Release reads the `## [0.34.2]` section (roll-then-tag). Exact steps handed
to the release orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
