### PR TITLE
feat(connectors): linux.script.run server-side secret_env Vault injection

### DIFF
--- a/backend/src/meho_backplane/connectors/linux/ops_write.py
+++ b/backend/src/meho_backplane/connectors/linux/ops_write.py
@@ -636,8 +636,7 @@ async def _resolve_secret_env(
                 # The underlying errors name the target / field / secret_ref
                 # path, never a credential value; add the ENV for the operator.
                 raise LinuxWriteError(
-                    f"secret_env[{name!r}] could not resolve vault reference "
-                    f"{path}#{field}: {exc}"
+                    f"secret_env[{name!r}] could not resolve vault reference {path}#{field}: {exc}"
                 ) from exc
             cache[path] = secret_data
         if not isinstance(secret_data, dict) or field not in secret_data:

--- a/backend/src/meho_backplane/connectors/linux/ops_write.py
+++ b/backend/src/meho_backplane/connectors/linux/ops_write.py
@@ -26,7 +26,12 @@ Tier table:
   ``umask 077`` temp path and execute it (optionally under sudo), capturing
   stdout / stderr / exit. Its ``arguments`` / ``env`` may carry secrets, so it
   is pinned ``credential_write`` and previews only at park time via its
-  bespoke builder (never the body / argument values / env values).
+  bespoke builder (never the body / argument values / env values). A credential
+  the script needs is instead passed by reference via ``secret_env``
+  (``ENV_NAME -> "<vault-path>#<field>"``), resolved from Vault server-side at
+  execution time (the same ``_resolve_secret`` seam the sudo password uses) and
+  injected as an env var -- only the mapping, never the value, is persisted on
+  the approval row / audit params.
 * ``linux.sysctl.write`` -- ``dangerous`` + approval (group ``system``). Set a
   kernel parameter (runtime ``sysctl -w`` + a persistent drop-in). Non-secret,
   so it previews via ``preview_operation`` on the generic params-echo default.
@@ -56,9 +61,14 @@ from __future__ import annotations
 
 import base64
 import shlex
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from meho_backplane.connectors._shared.vault_creds import strip_credential_value
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.vault_creds import (
+    CredentialsReadError,
+    strip_credential_value,
+)
 from meho_backplane.connectors.linux._sudo import run_remote_bash_with_sudo
 from meho_backplane.connectors.linux.ops import (
     SSH_TRANSPORT_NOTE,
@@ -177,6 +187,18 @@ _SYSCTL_VALUE_CHARSET: frozenset[str] = frozenset(
 _ENV_NAME_CHARSET: frozenset[str] = frozenset(
     "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"
 )
+
+#: Upper bound on the number of ``secret_env`` entries one ``script.run`` may
+#: declare -- a bounded fan-out of per-call Vault reads, not an open-ended loop.
+_MAX_SECRET_ENV: int = 32
+
+#: env-var names ``secret_env`` must NOT bind: the ``script.run`` wrapper's own
+#: shell variables (:func:`build_script_run_wrapper` sets ``tmp`` and, when
+#: arguments are present, ``args``; the sudo primitive uses ``f``). Binding one
+#: from a resolved secret would clobber the wrapper's control state -- the temp
+#: path it executes and then removes -- so a collision is refused *before* any
+#: Vault read. ``env`` is left unchanged; this guard is ``secret_env``-only.
+_RESERVED_ENV_NAMES: frozenset[str] = frozenset({"tmp", "args", "f"})
 
 #: Hard cap + default for ``linux.script.run``'s wall-clock timeout.
 _DEFAULT_TIMEOUT_S: int = 120
@@ -501,6 +523,131 @@ def _bounded_timeout(raw: Any) -> int:
     return min(value, _MAX_TIMEOUT_S)
 
 
+@dataclass(frozen=True)
+class _VaultRefTarget:
+    """Minimal target shape for a one-off ``secret_env`` Vault read.
+
+    :meth:`SshConnector._resolve_secret` reads ``secret_ref`` under the
+    operator's identity via ``load_vault_secret_data``; that read needs only
+    ``name`` / ``host`` (non-secret log attribution) and ``secret_ref`` (the
+    logical KV-v2 path). This stub carries the operator-supplied vault path as
+    ``secret_ref`` while borrowing the real target's ``name`` / ``host`` for
+    attribution, so a ``secret_env`` read is scoped, logged, and fail-closed
+    exactly like the sudo-password read -- one Vault client path, not a fork.
+    """
+
+    name: str
+    host: str
+    secret_ref: str
+
+
+def _validate_secret_env(raw: Any, *, env_names: set[str]) -> dict[str, tuple[str, str]]:
+    """Validate the ``secret_env`` mapping into ``{ENV_NAME: (vault_path, field)}``.
+
+    Each key is a POSIX env-var name (the ``env`` charset, not starting with a
+    digit) that must not collide with a reserved wrapper variable
+    (:data:`_RESERVED_ENV_NAMES`) or with a name already declared in ``env`` --
+    a name resolved from Vault and a name set literally must be unambiguous.
+    Each value is a ``"<vault-path>#<field>"`` reference: exactly one ``#``, a
+    non-empty logical KV-v2 path (same convention ``load_vault_secret_data``
+    accepts -- relative to the ``secret`` mount, never an API-path-shaped
+    ``secret/data/...``), a non-empty field, and no control characters. The
+    *reference* is validated here (fail-closed, before any SSH / Vault I/O);
+    the *value* is resolved later, at execution time, and never stored. Raises
+    :class:`LinuxWriteSafetyError` on any malformed entry, naming the ENV / the
+    reference -- never a resolved value (none exists yet).
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise LinuxWriteSafetyError(
+            "secret_env must be an object of ENV_NAME -> '<vault-path>#<field>'"
+        )
+    if len(raw) > _MAX_SECRET_ENV:
+        raise LinuxWriteSafetyError(
+            f"secret_env declares {len(raw)} entries; the maximum is {_MAX_SECRET_ENV}"
+        )
+    refs: dict[str, tuple[str, str]] = {}
+    for name, ref in raw.items():
+        if not isinstance(name, str) or not name or not set(name) <= _ENV_NAME_CHARSET:
+            raise LinuxWriteSafetyError(f"secret_env var name {name!r} is not a valid POSIX name")
+        if name[0].isdigit():
+            raise LinuxWriteSafetyError(f"secret_env var name {name!r} must not start with a digit")
+        if name in _RESERVED_ENV_NAMES:
+            raise LinuxWriteSafetyError(
+                f"secret_env var name {name!r} collides with a reserved wrapper variable"
+            )
+        if name in env_names:
+            raise LinuxWriteSafetyError(
+                f"secret_env var name {name!r} is also declared in env; a name must not "
+                "appear in both"
+            )
+        if not isinstance(ref, str) or ref.count("#") != 1:
+            raise LinuxWriteSafetyError(
+                f"secret_env[{name!r}] must be a single '<vault-path>#<field>' reference"
+            )
+        if any(ch in ref for ch in ("\x00", "\n", "\r")):
+            raise LinuxWriteSafetyError(f"secret_env[{name!r}] contains a control character")
+        path, _, field = ref.partition("#")
+        path, field = path.strip(), field.strip()
+        if not path or not field:
+            raise LinuxWriteSafetyError(
+                f"secret_env[{name!r}] must give a non-empty vault path and field "
+                "('<vault-path>#<field>')"
+            )
+        refs[name] = (path, field)
+    return refs
+
+
+async def _resolve_secret_env(
+    connector: LinuxSshConnector,
+    target: Any,
+    operator: Operator | None,
+    refs: dict[str, tuple[str, str]],
+) -> dict[str, str]:
+    """Resolve every validated ``secret_env`` reference to its value at run time.
+
+    For each ``ENV_NAME -> (vault_path, field)`` this reads the KV-v2 secret at
+    ``vault_path`` through the connector's single Vault seam
+    (:meth:`SshConnector._resolve_secret`, the same one the sudo password uses)
+    under the dispatching operator's identity, and pulls ``field`` out. Reads
+    are de-duplicated per path so several fields of one secret cost a single
+    Vault round-trip. A missing field, an unresolvable / forbidden path, or any
+    Vault error raises :class:`LinuxWriteError` naming the ENV and the reference
+    -- never a value -- so the caller fails closed *before* any remote
+    execution. The returned ``{name: value}`` dict is ephemeral: it is merged
+    into the wrapper env and never enters ``params`` / audit / the result / a
+    log line.
+    """
+    if not refs:
+        return {}
+    label = _target_label(target)
+    host_raw = getattr(target, "host", None)
+    host = host_raw if isinstance(host_raw, str) and host_raw else "unknown"
+    resolved: dict[str, str] = {}
+    cache: dict[str, dict[str, Any]] = {}
+    for name, (path, field) in refs.items():
+        secret_data = cache.get(path)
+        if secret_data is None:
+            stub = _VaultRefTarget(name=label, host=host, secret_ref=path)
+            try:
+                secret_data = await connector._resolve_secret(stub, operator)
+            except (VaultClientError, CredentialsReadError) as exc:
+                # The underlying errors name the target / field / secret_ref
+                # path, never a credential value; add the ENV for the operator.
+                raise LinuxWriteError(
+                    f"secret_env[{name!r}] could not resolve vault reference "
+                    f"{path}#{field}: {exc}"
+                ) from exc
+            cache[path] = secret_data
+        if not isinstance(secret_data, dict) or field not in secret_data:
+            raise LinuxWriteError(
+                f"secret_env[{name!r}] vault path {path!r} has no field {field!r}"
+            )
+        resolved[name] = strip_credential_value(secret_data[field])
+    return resolved
+
+
 def build_script_run_wrapper(
     interpreter: str,
     script: str,
@@ -563,6 +710,13 @@ async def linux_script_run(
     ``stdout`` is a list of lines that spills to a ``result_query`` handle when
     large. The intentional arbitrary-code surface -- a typed verb governed by
     approval, not an interactive shell.
+
+    ``secret_env`` (optional) maps ``ENV_NAME -> "<vault-path>#<field>"``; each
+    reference is resolved server-side from Vault at this point -- execution time
+    -- under the dispatching operator, and injected as an env var alongside
+    ``env``. Only the mapping (never a resolved value) is persisted on the
+    approval row / audit params, so a script can receive a credential without a
+    bare secret ever landing on the durable park.
     """
     script = params["script"]
     if not isinstance(script, str):
@@ -577,15 +731,28 @@ async def linux_script_run(
     if working_directory is not None:
         working_directory = _validate_abspath(working_directory, "working_directory")
     env = _validate_env(params.get("env"))
+    secret_env_refs = _validate_secret_env(params.get("secret_env"), env_names=set(env))
     timeout = _bounded_timeout(params.get("timeout_seconds"))
     use_sudo = bool(params.get("use_sudo", False))
+
+    # Resolve secret_env at EXECUTION time only. This handler runs on the
+    # ``_approved=True`` resume path (or a non-parking dispatch), never at park
+    # time, so a resolved value never lands on ``ApprovalRequest.params`` -- the
+    # row keeps only the ENV -> path#field mapping. Resolution happens *before*
+    # any remote command is built or run, so a bad reference fails closed with
+    # no partial execution. The resolved values are merged into the wrapper env
+    # exactly like the literal ``env`` (base64-carried, umask-077 temp) and are
+    # never persisted. A collision between ``env`` and ``secret_env`` names was
+    # already refused in validation, so this merge overwrites nothing.
+    resolved_secret_env = await _resolve_secret_env(connector, target, operator, secret_env_refs)
+    combined_env = {**env, **resolved_secret_env}
 
     wrapper = build_script_run_wrapper(
         interpreter,
         script,
         arguments=arguments,
         working_directory=working_directory,
-        env=env,
+        env=combined_env,
     )
 
     if use_sudo:
@@ -807,10 +974,11 @@ async def _linux_script_run_preview(ctx: PreviewContext) -> dict[str, Any] | Non
     ``env`` may carry secrets), so ``preview_operation`` returns
     ``preview_unavailable`` for it; this bespoke builder runs *at park time* and
     echoes only the *shape*: the target, the interpreter, the script byte size,
-    the argument byte size, the env-var NAMES, the working directory, the sudo
-    intent, and the timeout -- never the script body, the argument values, or
-    the env values (mirrors the guest program-run precedent). Declines
-    (``None``) on malformed params.
+    the argument byte size, the env-var NAMES, the ``secret_env`` reference
+    mapping (non-secret ``ENV -> path#field`` Vault pointers), the working
+    directory, the sudo intent, and the timeout -- never the script body, the
+    argument values, or the env values (mirrors the guest program-run
+    precedent). Declines (``None``) on malformed params.
     """
     script = ctx.params.get("script")
     if not isinstance(script, str):
@@ -828,6 +996,14 @@ async def _linux_script_run_preview(ctx: PreviewContext) -> dict[str, Any] | Non
     env = ctx.params.get("env")
     if isinstance(env, dict) and env:
         preview["env_var_names"] = sorted(str(name) for name in env)
+    secret_env = ctx.params.get("secret_env")
+    if isinstance(secret_env, dict) and secret_env:
+        # The references are non-secret Vault pointers (``path#field``) -- the
+        # only thing ``secret_env`` ever persists -- so echoing the full
+        # mapping shows the reviewer WHICH credential each env var will receive
+        # at run time. No value exists at park time, so nothing here can leak
+        # one (the values are resolved only when the approved call executes).
+        preview["secret_env"] = {str(name): str(ref) for name, ref in secret_env.items()}
     working_directory = ctx.params.get("working_directory")
     if isinstance(working_directory, str) and working_directory:
         preview["working_directory"] = working_directory
@@ -1020,7 +1196,11 @@ _SCRIPT_RUN_OP = LinuxOp(
         "Uploads an operator-declared script to a umask 077 temp path and runs "
         "it under interpreter (default /bin/bash), optionally under sudo, with "
         "an argument string, working directory, env map, and a wall-clock "
-        "timeout; the temp file is removed afterwards. This is the intentional "
+        "timeout; the temp file is removed afterwards. A credential the script "
+        "needs is passed by reference via secret_env (ENV_NAME -> "
+        "'<vault-path>#<field>'), resolved server-side from Vault at run time "
+        "and injected as an env var -- the resolved value is never stored on the "
+        "approval row, in audit params, or the result. This is the intentional "
         "arbitrary-code surface -- a typed verb governed by approval, NOT an "
         "interactive shell. safety_level=dangerous, requires_approval=true: it "
         "parks for a human. Returns {stdout, stderr, exit_code, ...}; stdout is "
@@ -1049,7 +1229,27 @@ _SCRIPT_RUN_OP = LinuxOp(
             "env": {
                 "type": "object",
                 "additionalProperties": {"type": "string"},
-                "description": "Optional env map. Do NOT put bare secrets in values.",
+                "description": (
+                    "Optional env map. Do NOT put bare secrets in values -- use "
+                    "secret_env for credentials."
+                ),
+            },
+            "secret_env": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": (
+                    "Optional map of ENV_NAME -> '<vault-path>#<field>'. Each "
+                    "value is resolved server-side at execution time from the "
+                    "Vault KV-v2 secret at <vault-path> (a logical path under the "
+                    "'secret' mount -- same convention as a target's secret_ref, "
+                    "NOT an API-path-shaped 'secret/data/...') and injected as the "
+                    "environment variable ENV_NAME for the script. The resolved "
+                    "secret value is NEVER stored on the approval row, in audit "
+                    "params, the result, or a log -- only this ENV_NAME -> "
+                    "reference mapping is persisted. Use this instead of putting a "
+                    "bare secret in arguments/env. A name must not repeat an env "
+                    "name or a reserved wrapper variable."
+                ),
             },
             "timeout_seconds": {
                 "type": "integer",
@@ -1086,15 +1286,21 @@ _SCRIPT_RUN_OP = LinuxOp(
         "when_to_use": (
             "Call to run an operator-declared remediation script on a Linux host "
             "-- re-run the aborted first-boot script, apply a multi-step fix. "
-            "Approval-gated arbitrary code: it parks for a human. Do NOT put "
-            "bare secrets in arguments/env (they are stored verbatim for the "
-            "approval re-dispatch). " + SSH_TRANSPORT_NOTE
+            "Approval-gated arbitrary code: it parks for a human. NEVER put bare "
+            "secrets in arguments/env -- they are stored verbatim for the approval "
+            "re-dispatch. When the script needs a credential, pass it via "
+            "secret_env (ENV_NAME -> '<vault-path>#<field>'): it is resolved from "
+            "Vault server-side at run time and never persisted. " + SSH_TRANSPORT_NOTE
         ),
         "parameter_hints": {
             "script": "The script body; no bare secrets.",
             "interpreter": "Absolute path; defaults to /bin/bash.",
             "arguments": "Optional command line; word-split.",
             "env": "Optional; no bare secrets in values.",
+            "secret_env": (
+                "Optional; ENV_NAME -> '<vault-path>#<field>' resolved from Vault "
+                "at run time (never persisted). Use for credentials."
+            ),
             "use_sudo": "Optional; run as root.",
         },
         "output_shape": (

--- a/backend/tests/test_connectors_linux_write.py
+++ b/backend/tests/test_connectors_linux_write.py
@@ -49,11 +49,15 @@ from meho_backplane.connectors.linux import LinuxSshConnector
 from meho_backplane.connectors.linux._sudo import build_sudo_bash_remote_cmd
 from meho_backplane.connectors.linux.ops import PathConfinementError
 from meho_backplane.connectors.linux.ops_write import (
+    _MAX_SECRET_ENV,
+    _RESERVED_ENV_NAMES,
     WRITE_OPS,
     LinuxWriteError,
     LinuxWriteSafetyError,
     _linux_file_write_preview,
     _linux_script_run_preview,
+    _resolve_secret_env,
+    _validate_secret_env,
     bound_firewall_backend,
     bound_service_action,
     build_file_write_script,
@@ -83,6 +87,13 @@ _CONTENT_CANARY = "MEHO_FILE_BODY_CANARY_DO_NOT_LEAK_zzq"  # gitleaks:allow -- s
 _SCRIPT_CANARY = "MEHO_SCRIPT_BODY_CANARY_DO_NOT_LEAK_zzq"  # gitleaks:allow -- synthetic
 _ARG_CANARY = "--flag MEHO_ARG_CANARY_zzq"
 _ENV_VALUE_CANARY = "MEHO_ENV_VALUE_CANARY_zzq"
+# The resolved-from-Vault secret_env value: must never surface in the wrapper
+# in the clear, in params, in the result, or in a preview.
+_SECRET_ENV_VALUE_CANARY = "MEHO_SECRETENV_VALUE_CANARY_zzq"  # gitleaks:allow -- synthetic
+# The non-secret Vault reference (logical KV-v2 path # field) secret_env carries.
+_SECRET_ENV_PATH = "kv/app/db"
+_SECRET_ENV_FIELD = "cred"
+_SECRET_ENV_REF = f"{_SECRET_ENV_PATH}#{_SECRET_ENV_FIELD}"
 
 
 # ---------------------------------------------------------------------------
@@ -789,3 +800,302 @@ async def test_service_control_caution_does_not_park(linux_write_registered: Non
     assert dumped["status"] == "ok", dumped
     assert dumped["status"] != "awaiting_approval"
     handler.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# secret_env: server-side Vault-ref injection for linux.script.run
+#
+# secret_env maps ENV_NAME -> "<vault-path>#<field>"; the value is resolved
+# server-side from Vault at execution time and injected into the wrapper env.
+# Only the (non-secret) mapping is ever persisted -- the resolved value never
+# lands on ApprovalRequest.params, audit params, the broadcast payload, the
+# result, or a log line. These tests pin that contract.
+# ---------------------------------------------------------------------------
+
+
+def _connector_with_vault(vault: dict[str, dict[str, Any]]) -> Any:
+    """A connector whose ``_resolve_secret`` returns per-secret_ref secret data.
+
+    The sudo password resolves from the real target's own secret (the default
+    branch); a ``secret_env`` read resolves from *vault* keyed on the stub
+    target's ``secret_ref`` (the operator-supplied Vault path). This mirrors the
+    single ``_resolve_secret`` Vault seam the production code funnels both reads
+    through.
+    """
+    connector = LinuxSshConnector()
+
+    def _resolve(target: Any, operator: Any = None) -> dict[str, Any]:
+        ref = getattr(target, "secret_ref", None)
+        if ref in vault:
+            return vault[ref]
+        return {"username": "root", "sudo_password": _SUDO_CANARY}
+
+    connector._resolve_secret = AsyncMock(side_effect=_resolve)  # type: ignore[method-assign]
+    return connector
+
+
+# -- parameter validation (good / bad names, syntax, count) -----------------
+
+
+def test_validate_secret_env_parses_good_refs_and_strips() -> None:
+    refs = _validate_secret_env(
+        {"APP_DB_CRED": f"  {_SECRET_ENV_PATH} # {_SECRET_ENV_FIELD} "},
+        env_names=set(),
+    )
+    assert refs == {"APP_DB_CRED": (_SECRET_ENV_PATH, _SECRET_ENV_FIELD)}
+    assert _validate_secret_env(None, env_names=set()) == {}
+
+
+def test_validate_secret_env_rejects_bad_names() -> None:
+    for bad in ("1LEADING_DIGIT", "has-dash", "has space", "", "PA;TH"):
+        with pytest.raises(LinuxWriteSafetyError):
+            _validate_secret_env({bad: _SECRET_ENV_REF}, env_names=set())
+
+
+def test_validate_secret_env_rejects_reserved_and_env_collision() -> None:
+    for reserved in _RESERVED_ENV_NAMES:
+        with pytest.raises(LinuxWriteSafetyError, match="reserved"):
+            _validate_secret_env({reserved: _SECRET_ENV_REF}, env_names=set())
+    with pytest.raises(LinuxWriteSafetyError, match="also declared in env"):
+        _validate_secret_env({"DUP": _SECRET_ENV_REF}, env_names={"DUP"})
+
+
+def test_validate_secret_env_rejects_bad_ref_syntax() -> None:
+    for bad_ref in ("no-hash", "two#hash#es", "#emptyPath", "kv/app/db#", "kv/app/db#\n"):
+        with pytest.raises(LinuxWriteSafetyError):
+            _validate_secret_env({"OK_NAME": bad_ref}, env_names=set())
+    with pytest.raises(LinuxWriteSafetyError):
+        _validate_secret_env({"OK_NAME": 123}, env_names=set())  # non-string ref
+    with pytest.raises(LinuxWriteSafetyError):
+        _validate_secret_env(["not", "a", "dict"], env_names=set())  # non-dict raw
+
+
+def test_validate_secret_env_enforces_count_cap() -> None:
+    too_many = {f"V{i}": _SECRET_ENV_REF for i in range(_MAX_SECRET_ENV + 1)}
+    with pytest.raises(LinuxWriteSafetyError, match="maximum"):
+        _validate_secret_env(too_many, env_names=set())
+
+
+# -- resolution + injection (mocked Vault): value reaches the wrapper, not params
+
+
+@pytest.mark.asyncio
+async def test_secret_env_value_reaches_wrapper_env_not_params_or_result() -> None:
+    """AC: the resolved secret reaches the remote wrapper env (base64-carried),
+    never the params dict, never the returned result."""
+    connector = _connector_with_vault(
+        {_SECRET_ENV_PATH: {_SECRET_ENV_FIELD: _SECRET_ENV_VALUE_CANARY}}
+    )
+    params = {
+        "script": "echo hi",
+        "use_sudo": True,
+        "secret_env": {"APP_DB_CRED": _SECRET_ENV_REF},
+    }
+    sudo_mock = AsyncMock(return_value=_proc(stdout="hi\n", exit_status=0))
+    with patch("meho_backplane.connectors.linux.ops_write.run_remote_bash_with_sudo", sudo_mock):
+        result = await linux_script_run(connector, _TARGET, params)
+    # The wrapper (3rd positional arg) exports the env var and carries the value
+    # base64-encoded -- never in the clear.
+    wrapper = sudo_mock.await_args.args[2]
+    assert _SECRET_ENV_VALUE_CANARY not in wrapper
+    assert "export APP_DB_CRED=" in wrapper
+    assert _SECRET_ENV_VALUE_CANARY in _decode_b64_tokens(wrapper)
+    # The value is never written back into params (only the mapping) nor the result.
+    assert params["secret_env"] == {"APP_DB_CRED": _SECRET_ENV_REF}
+    assert _SECRET_ENV_VALUE_CANARY not in repr(params)
+    assert _SECRET_ENV_VALUE_CANARY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_secret_env_resolves_on_non_sudo_path_too() -> None:
+    """AC: secret_env is resolved + injected on the non-sudo dispatch path too."""
+    connector = _connector_with_vault(
+        {_SECRET_ENV_PATH: {_SECRET_ENV_FIELD: _SECRET_ENV_VALUE_CANARY}}
+    )
+    run_command = AsyncMock(return_value=_proc(stdout="ok\n", exit_status=0))
+    connector._run_command = run_command  # type: ignore[method-assign]
+    with patch("meho_backplane.connectors.linux.ops_write.run_remote_bash_with_sudo", AsyncMock()):
+        await linux_script_run(
+            connector,
+            _TARGET,
+            {
+                "script": "echo ok",
+                "use_sudo": False,
+                "secret_env": {"APP_DB_CRED": _SECRET_ENV_REF},
+            },
+        )
+    cmd = run_command.await_args.args[1]  # bash -c '<wrapper>'
+    assert _SECRET_ENV_VALUE_CANARY not in cmd
+    assert _SECRET_ENV_VALUE_CANARY in _decode_b64_tokens(cmd)
+
+
+@pytest.mark.asyncio
+async def test_secret_env_multiple_fields_one_secret_dedup_read() -> None:
+    """Several fields of one Vault path cost a single _resolve_secret read."""
+    connector = _connector_with_vault(
+        {_SECRET_ENV_PATH: {"user": "svc", "pass_ref": _SECRET_ENV_VALUE_CANARY}}
+    )
+    refs = _validate_secret_env(
+        {"U": f"{_SECRET_ENV_PATH}#user", "P": f"{_SECRET_ENV_PATH}#pass_ref"},
+        env_names=set(),
+    )
+    resolved = await _resolve_secret_env(connector, _TARGET, _OPERATOR, refs)
+    assert resolved == {"U": "svc", "P": _SECRET_ENV_VALUE_CANARY}
+    # One path -> one Vault read, even for two fields.
+    assert connector._resolve_secret.await_count == 1
+
+
+# -- resume-path re-resolution: resolved at execution time, not at park time
+
+
+@pytest.mark.asyncio
+async def test_secret_env_resolved_at_execution_reading_the_operator_supplied_path() -> None:
+    """AC: resolution runs when the handler executes (the approval-execution /
+    resume point), reading the operator-supplied Vault path at that time."""
+    connector = _connector_with_vault(
+        {_SECRET_ENV_PATH: {_SECRET_ENV_FIELD: _SECRET_ENV_VALUE_CANARY}}
+    )
+    with patch(
+        "meho_backplane.connectors.linux.ops_write.run_remote_bash_with_sudo",
+        AsyncMock(return_value=_proc(stdout="", exit_status=0)),
+    ):
+        await linux_script_run(
+            connector,
+            _TARGET,
+            {"script": "x", "use_sudo": True, "secret_env": {"APP_DB_CRED": _SECRET_ENV_REF}},
+        )
+    resolved_refs = [c.args[0].secret_ref for c in connector._resolve_secret.await_args_list]
+    assert _SECRET_ENV_PATH in resolved_refs  # the secret_env path was read at execution
+
+
+# -- fail-closed: missing field / forbidden path -> structured error, no run
+
+
+@pytest.mark.asyncio
+async def test_secret_env_missing_field_fails_closed_no_ssh() -> None:
+    """AC: a missing field errors before any remote execution, naming ENV+field."""
+    connector = _connector_with_vault({_SECRET_ENV_PATH: {"other_field": "x"}})
+    sudo_mock = AsyncMock()
+    with (
+        patch("meho_backplane.connectors.linux.ops_write.run_remote_bash_with_sudo", sudo_mock),
+        pytest.raises(LinuxWriteError) as exc,
+    ):
+        await linux_script_run(
+            connector,
+            _TARGET,
+            {"script": "x", "use_sudo": True, "secret_env": {"APP_DB_CRED": _SECRET_ENV_REF}},
+        )
+    sudo_mock.assert_not_awaited()
+    assert "APP_DB_CRED" in str(exc.value)
+    assert _SECRET_ENV_FIELD in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_secret_env_forbidden_path_fails_closed_no_ssh() -> None:
+    """AC: an unresolvable / forbidden (API-path-shaped) vault path fails closed."""
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+
+    connector = LinuxSshConnector()
+
+    def _resolve(target: Any, operator: Any = None) -> dict[str, Any]:
+        if getattr(target, "secret_ref", None) == "secret/data/forbidden":
+            raise VaultCredentialsReadError(
+                "target has a KV-v2 API-path-shaped secret_ref 'secret/data/forbidden'"
+            )
+        return {"username": "root", "sudo_password": _SUDO_CANARY}
+
+    connector._resolve_secret = AsyncMock(side_effect=_resolve)  # type: ignore[method-assign]
+    sudo_mock = AsyncMock()
+    with (
+        patch("meho_backplane.connectors.linux.ops_write.run_remote_bash_with_sudo", sudo_mock),
+        pytest.raises(LinuxWriteError) as exc,
+    ):
+        await linux_script_run(
+            connector,
+            _TARGET,
+            {
+                "script": "x",
+                "use_sudo": True,
+                "secret_env": {"APP_DB_CRED": "secret/data/forbidden#cred"},
+            },
+        )
+    sudo_mock.assert_not_awaited()
+    assert "APP_DB_CRED" in str(exc.value)
+
+
+# -- op schema + preview echo (reference mapping, never a value)
+
+
+def test_script_run_op_declares_secret_env_param() -> None:
+    op = _op("linux.script.run")
+    props = op.parameter_schema["properties"]
+    assert "secret_env" in props
+    assert props["secret_env"]["type"] == "object"
+    assert op.parameter_schema["additionalProperties"] is False
+    assert "secret_env" in op.llm_instructions["parameter_hints"]
+
+
+@pytest.mark.asyncio
+async def test_script_run_preview_echoes_secret_env_refs_never_values() -> None:
+    ctx = types.SimpleNamespace(
+        params={"script": _SCRIPT_CANARY, "secret_env": {"APP_DB_CRED": _SECRET_ENV_REF}},
+        target=types.SimpleNamespace(name="linux-1"),
+    )
+    preview = await _linux_script_run_preview(ctx)  # type: ignore[arg-type]
+    # The non-secret reference (path#field) is shown to the reviewer; no resolved
+    # value exists at park time, so none can leak here.
+    assert preview["secret_env"] == {"APP_DB_CRED": _SECRET_ENV_REF}
+    assert _SECRET_ENV_VALUE_CANARY not in repr(preview)
+
+
+# -- approval-row + audit + broadcast redaction (DB-backed park)
+
+
+@pytest.mark.asyncio
+async def test_park_persists_secret_env_mapping_only_never_value(
+    linux_write_registered: None,
+) -> None:
+    """AC: a parked script.run stores only the ENV -> path#field mapping on the
+    approval row (and its proposed_effect); the resolved value appears nowhere
+    -- at park time it is not even resolved. Broadcast is aggregate-clamped for
+    this credential_write op (see test_credential_bearing_writes_are_pinned_*)."""
+    from sqlalchemy import select
+
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import ApprovalRequest
+    from meho_backplane.operations import dispatch
+    from meho_backplane.targets.resolver import resolve_target
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = await resolve_target(session, _OPERATOR.tenant_id, _TARGET_NAME)
+    params = {"script": _SCRIPT_CANARY, "secret_env": {"APP_DB_CRED": _SECRET_ENV_REF}}
+    result = await dispatch(
+        operator=_OPERATOR,
+        connector_id=_CONNECTOR_ID,
+        op_id="linux.script.run",
+        target=target,
+        params=params,
+        _approved=False,
+    )
+    dumped = result.model_dump(mode="json")
+    assert dumped["status"] == "awaiting_approval", dumped
+    request_id = dumped["extras"]["approval_request_id"]
+
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(ApprovalRequest).where(ApprovalRequest.id == uuid.UUID(request_id))
+            )
+        ).scalar_one()
+
+    # The mapping is persisted verbatim so the approved call can re-resolve it.
+    assert row.params["secret_env"] == {"APP_DB_CRED": _SECRET_ENV_REF}
+    # The resolved value is absent everywhere durable (it is never resolved at park).
+    assert _SECRET_ENV_VALUE_CANARY not in str(row.params)
+    assert _SECRET_ENV_VALUE_CANARY not in str(row.proposed_effect)
+    assert _SECRET_ENV_VALUE_CANARY not in str(dumped)
+    # The park-time bespoke preview (nested under "preview") echoes the
+    # (non-secret) reference mapping so the reviewer sees the credential source.
+    assert row.proposed_effect is not None
+    assert row.proposed_effect["preview"]["secret_env"] == {"APP_DB_CRED": _SECRET_ENV_REF}

--- a/docs/codebase/connectors-linux.md
+++ b/docs/codebase/connectors-linux.md
@@ -199,7 +199,7 @@ in `ops_write.py`; the root-elevation primitive lives in `_sudo.py`.
 |---|---|---|---|---|
 | `linux.file.write` | `file` | `dangerous` + approval | `path`, `content`, `validate_command?`, `backup?` | `{written, path, backup_path, validated, rolled_back}` |
 | `linux.service.control` | `service` | `caution` (no approval) | `action`, `unit`, `daemon_reload?` | `{unit, action, daemon_reload, ok}` |
-| `linux.script.run` | `exec` | `dangerous` + approval | `script`, `interpreter?`, `arguments?`, `working_directory?`, `env?`, `timeout_seconds?`, `use_sudo?` | `{stdout, total, stderr, exit_code, interpreter, used_sudo}` |
+| `linux.script.run` | `exec` | `dangerous` + approval | `script`, `interpreter?`, `arguments?`, `working_directory?`, `env?`, `secret_env?`, `timeout_seconds?`, `use_sudo?` | `{stdout, total, stderr, exit_code, interpreter, used_sudo}` |
 | `linux.sysctl.write` | `system` | `dangerous` + approval | `key`, `value` | `{key, value, applied, dropin_path}` |
 | `linux.firewall.load` | `firewall` | `dangerous` + approval | `ruleset`, `backend?` | `{applied, backend, validated}` |
 
@@ -257,8 +257,10 @@ differently, by design:
   (`register_preview_builder`, fail-soft) that echoes only shape — path +
   content byte size + backup path + validate command for `file.write`;
   interpreter + script byte size + argument byte size + env-var **names** +
-  working directory + sudo intent + timeout for `script.run` — and **never**
-  the `content` / script body / argument values / env values.
+  the `secret_env` **reference mapping** (`ENV → <vault-path>#<field>`, the
+  non-secret Vault pointers) + working directory + sudo intent + timeout for
+  `script.run` — and **never** the `content` / script body / argument values /
+  env values / resolved `secret_env` values.
 - `linux.sysctl.write` and `linux.firewall.load` carry no secret, so they
   register **no** bespoke builder and stay previewable via
   `preview_operation` on the generic params-echo default. For
@@ -281,8 +283,59 @@ op's job) and `/var/log` are deliberately not writable here.
 `content` / `arguments` / `env`. `ApprovalRequest.params` stores the params
 verbatim so the approved call can be re-dispatched, so a secret placed
 there is durable on the approval row (the same rule as the guest
-`program.run` / `file.write` verbs). Pass a Vault reference the script
-resolves at run time instead.
+`program.run` / `file.write` verbs). For `script.run`, pass the credential by
+reference via `secret_env` (below) — the backplane resolves it server-side at
+run time, so the value never touches the params.
+
+### Server-side secret injection (`secret_env`)
+
+`script.run` is `safety_level=dangerous`, `requires_approval=True`, and pinned
+`credential_write`: its `script` / `arguments` / `env` are base64-carried on
+the wire but stored **verbatim** in `ApprovalRequest.params` (needed to
+re-dispatch the exact call on approval) and in the audit params. That is the
+right design for re-dispatch, but it means a script cannot safely *receive* a
+credential through `arguments` / `env` — any secret placed there is durable on
+the approval row and in audit. The only server-side secret resolution the
+connector otherwise performs is the sudo password (`_resolve_sudo_password`,
+read from the target's own Vault secret) and the SSH auth material.
+
+The anti-pattern this replaces: passing a non-secret Vault *path* as an
+argument and resolving it **on the host** — which requires a Vault CLI and a
+Vault token to be present on the target (a live credential parked on a third
+host), exactly the un-governed footgun this connector exists to retire.
+
+`secret_env` closes that gap. It is an optional object mapping
+`ENV_NAME → "<vault-path>#<field>"`:
+
+- **Reference shape.** `<vault-path>` is a logical KV-v2 path under the
+  `secret` mount — the same convention `load_vault_secret_data` accepts for the
+  connector (a `targets/<id>`-style path, **not** an API-path-shaped
+  `secret/data/…`). `#<field>` names the field within that secret. Each
+  `ENV_NAME` must be a valid POSIX identifier, must not start with a digit,
+  must not collide with a reserved wrapper variable (`tmp` / `args` / `f`) or
+  with a name already declared in `env`, and the mapping is bounded (≤ 32
+  entries).
+- **Resolution at execution time only.** The value is resolved when the handler
+  runs — the `_approved=True` resume path (or a non-parking dispatch) — never at
+  park time. Each field is read through the connector's single Vault seam
+  (`_resolve_secret` → `load_vault_secret_data`, reused, not forked) under the
+  **dispatching operator's** identity / tenant scope — the same scoping the
+  sudo-password resolution uses — then injected into the remote wrapper as an
+  env var exactly like `env` (base64-carried, `umask 077` temp handling).
+  Reads are de-duplicated per path.
+- **Never persisted.** `ApprovalRequest.params`, the audit params, and the
+  broadcast payload carry only the `ENV → <vault-path>#<field>` mapping; the
+  resolved value never enters params, the `OperationResult`, the park-time
+  preview, or a log line. The park-time bespoke preview echoes the reference
+  mapping (a non-secret pointer) so the reviewer can see *which* credential each
+  env var will receive, but no value exists at park to leak.
+- **Fail closed.** A missing field, a forbidden / API-path-shaped path, or any
+  Vault resolution error raises a structured error **before** any remote
+  command is built or run (no partial execution). The error names the `ENV`
+  and the `<vault-path>#<field>` reference — never a resolved value.
+
+`env` behaviour is unchanged. `secret_env` is `script.run`-scoped; the
+connector has no `command.run` verb to extend it to.
 
 ## Key types
 


### PR DESCRIPTION
Closes #3536.

## Problem

`linux.script.run` is `safety_level=dangerous`, `requires_approval=True`, and pinned `credential_write`. Its `script` / `arguments` / `env` are base64-carried on the wire but stored **verbatim** in `ApprovalRequest.params` (needed to re-dispatch the exact call on approval) and in the audit params. That is the right design for re-dispatch, but it means a governed remote build/bootstrap script that needs a credential cannot safely *receive* one: any secret passed via `arguments` / `env` is durable on the approval row and in audit.

This is the `script.run`-specific mitigation for the general "credential_write parks persist raw secret values on the approval row" problem tracked in #3537 — `secret_env` keeps the value out of `params` entirely by resolving it server-side at execution time.

The only prior workaround was to pass a non-secret Vault *path* and resolve it **on the host**, which requires a Vault CLI + token to be present on the target (a live credential parked on a third host) — the un-governed footgun this connector exists to retire. The connector already resolves the sudo password and SSH auth material server-side; `secret_env` extends that same pattern to script credentials.

## Change

Add an optional `secret_env` parameter to `linux.script.run` mapping `ENV_NAME -> "<vault-path>#<field>"`:

1. **Validated fail-closed** before any SSH/Vault I/O: `ENV_NAME` is a POSIX identifier that must not start with a digit, collide with a reserved wrapper variable (`tmp` / `args` / `f`), or repeat an `env` name; the reference must be a single `path#field` with a non-empty logical KV-v2 path (same convention `load_vault_secret_data` accepts — a `targets/<id>`-style path under the `secret` mount, **not** an API-path-shaped `secret/data/…`) and field; the mapping is bounded (≤ 32 entries).
2. **Resolved at execution time only** — the `_approved=True` resume path or a non-parking dispatch, never at park time — through the connector's single `_resolve_secret` → `load_vault_secret_data` seam (reused, not forked) under the **dispatching operator's** identity/tenant scope, exactly as the sudo-password resolution scopes. Injected into the remote wrapper as an env var like the existing `env` (base64-carried, `umask 077` temp). Reads are de-duplicated per path.
3. **Never persisted.** `ApprovalRequest.params`, audit params, and the broadcast payload carry only the `ENV -> path#field` mapping; the resolved value never enters `params`, the `OperationResult`, the preview, or a log line. The park-time bespoke preview echoes the (non-secret) reference mapping so the reviewer sees which credential each env var will receive.
4. **Fail closed** on a missing field, a forbidden / API-path-shaped path, or any Vault resolution error: a structured error naming the `ENV` + the `path#field` reference (never a value), raised before any remote execution (no partial run).

`env` behaviour is unchanged. `secret_env` is `script.run`-scoped; the connector has no `command.run` verb to extend it to.

## Tests

New coverage in `test_connectors_linux_write.py` (14 tests): parameter validation (names / syntax / reserved+env collision / count cap); resolution + injection with a mocked Vault (value reaches the wrapper env base64-carried, never `params` or the result) on both the sudo and non-sudo paths; per-path read de-duplication; resolution at execution time (reads the operator-supplied path when the handler runs); fail-closed on missing field and forbidden path (no remote execution); the op schema declares `secret_env`; the park-time preview echoes the reference mapping never a value; and a DB-backed park test asserting `ApprovalRequest.params` + `proposed_effect` carry only the mapping with the resolved-value canary absent everywhere.

Docs: a `secret_env` section in `docs/codebase/connectors-linux.md` with the approval-row-persists-params rationale and the on-host-vault-CLI anti-pattern it replaces.

## Verification

- Targeted: `test_connectors_linux_write.py` 56 passed (42 existing + 14 new).
- Guards: `test_reference_docs_drift.py` + `test_flight_recorder_typed_spans.py` (F8 typed-span family coverage) green.
- CLI OpenAPI snapshot (`cli/api/openapi.json`) regenerated — no drift (op param schemas are DB-delivered, not in the FastAPI snapshot).
- Full unit sweep (excluding the service-backed `tests/integration` + `tests/acceptance` tiers): 15439 passed; the only failures are environment-dependent (Postgres/Valkey services, network sockets, `helm template`) and unrelated to this change.

No CHANGELOG entry in this PR (merge-queue convention: CHANGELOG lands in a separate docs-only PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)