### PR TITLE
docs(changelog): entry for linux.script.run secret_env (#3536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- `linux.script.run` gains an optional `secret_env` map (`ENV_NAME -> "<vault-path>#<field>"`): the referenced Vault secret is resolved server-side under the dispatching operator's tenant scope at execution time and injected into the remote script's environment, so a governed bootstrap/build script can receive a credential without it ever persisting. `ApprovalRequest.params`, the audit params, the broadcast payload and the park preview carry only the `ENV -> path#field` reference mapping — the resolved value never enters `params`, the `OperationResult`, the preview or a log line. Fail-closed name/reference validation (POSIX env names, no reserved-wrapper/`env` collisions, bounded to 32 entries, rejects API-path-shaped refs) runs before any SSH/Vault I/O, and resolution reuses the connector's existing `_resolve_secret` seam under the same scoping as the sudo password. Retires the prior on-host Vault-CLI workaround that parked a live token on the target. (#3536 / #3539)
+
 ## [0.34.2] - 2026-09-10
 
 ### Fixed


### PR DESCRIPTION
Docs-only. Adds the single `[Unreleased]` → **Added** CHANGELOG bullet for the feature landing in PR #3539 (`linux.script.run` server-side `secret_env` Vault-ref injection, Closes #3536). No code changes.

The code PR #3539 deliberately carries no CHANGELOG line — per the merge-queue convention, CHANGELOG entries land in separate docs-only PRs because CHANGELOG textual conflicts eject entries from merge-queue group builds.

## Hold / ordering

**Do NOT enqueue this until PR #3539 has merged.** Enqueuing both together risks a CHANGELOG group-build conflict that ejects one of them. Sequence: land #3539 first, then enqueue this docs-only PR.

## Entry

Under `## [Unreleased]` → `### Added`:

> `linux.script.run` gains an optional `secret_env` map — the referenced Vault secret is resolved server-side at execution time and injected into the remote script's environment; `ApprovalRequest.params` / audit / broadcast / preview carry only the `ENV -> path#field` reference, never the resolved value. Retires the on-host Vault-CLI workaround. (#3536 / #3539)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
