### PR TITLE
docs(changelog): roll [Unreleased] into 0.34.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.34.3] - 2026-09-12
+
 ### Added
 
 - `linux.script.run` gains an optional `secret_env` map (`ENV_NAME -> "<vault-path>#<field>"`): the referenced Vault secret is resolved server-side under the dispatching operator's tenant scope at execution time and injected into the remote script's environment, so a governed bootstrap/build script can receive a credential without it ever persisting. `ApprovalRequest.params`, the audit params, the broadcast payload and the park preview carry only the `ENV -> path#field` reference mapping — the resolved value never enters `params`, the `OperationResult`, the preview or a log line. Fail-closed name/reference validation (POSIX env names, no reserved-wrapper/`env` collisions, bounded to 32 entries, rejects API-path-shaped refs) runs before any SSH/Vault I/O, and resolution reuses the connector's existing `_resolve_secret` seam under the same scoping as the sudo password. Retires the prior on-host Vault-CLI workaround that parked a live token on the target. (#3536 / #3539)


### PR DESCRIPTION
## What

Release prep for **v0.34.3** (tag-driven patch). Rolls the single
`[Unreleased]` entry — the `linux.script.run` `secret_env` server-side
Vault-injection support (#3536 / #3539) — into a new dated
`## [0.34.3] - 2026-09-12` section placed directly above `## [0.34.2]`,
leaving a fresh empty `[Unreleased]`. CHANGELOG / release-notes detail
only; **no code, no `Chart.yaml`/appVersion bump** (the git tag stays the
sole version source, per `docs/RELEASING.md`).

The insertion mirrors the #3531 roll exactly: the new dated heading is
placed between `## [Unreleased]` and its content, so the entry that was
under `[Unreleased]` now falls under `## [0.34.3]` and `[Unreleased]` is
left empty. `[0.34.2]` and `[0.34.1]` are untouched.

## Entries rolled into 0.34.3

- **Added** — `linux.script.run` gains an optional `secret_env` map: a
  referenced Vault secret is resolved server-side under the dispatching
  operator's tenant scope at execution time and injected into the remote
  script's environment; only the `ENV -> path#field` reference mapping
  enters `ApprovalRequest.params`, the audit params, the broadcast
  payload and the park preview — the resolved value never enters
  `params`, the `OperationResult`, the preview or a log line. Retires the
  prior on-host Vault-CLI workaround that parked a live token on the
  target. (#3536 / #3539)

## Post-merge

Do **not** tag until this lands on `main` with a green run. The v0.34.3
tag must point at this PR's merge commit so the auto-published GitHub
Release reads the `## [0.34.3]` section (roll-then-tag). Exact steps
handed to the release orchestrator.

## Notes

- No compare-link footer is added: this CHANGELOG has never used one
  (matches #3525 / #3531).
- CHANGELOG.md only, mirroring the #3531 roll. `docs-site/reference/whats-new.md`
  is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
