### PR TITLE
feat(connectors): net.ssh_keyscan — governed SSH host-key pin through the backplane

### DIFF
--- a/backend/src/meho_backplane/connectors/net/__init__.py
+++ b/backend/src/meho_backplane/connectors/net/__init__.py
@@ -35,6 +35,7 @@ from meho_backplane.connectors.net.http_probe import register_net_http_probe_ope
 from meho_backplane.connectors.net.icmp import register_net_icmp_operations
 from meho_backplane.connectors.net.ntp import register_net_ntp_check_operation
 from meho_backplane.connectors.net.ops import register_net_typed_operations
+from meho_backplane.connectors.net.ssh_keyscan import register_net_ssh_keyscan_operation
 from meho_backplane.connectors.net.tls import register_net_tls_inspect_operation
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
@@ -43,17 +44,19 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # its own registrar so the family extends without editing a shared
 # function body (net.tcp_check #2406, net.tls_inspect #2407,
 # net.http_probe #2408, net.dns_lookup #2409, net.ntp_check #2410,
-# net.ping/trace/path_mtu #2411, …).
+# net.ping/trace/path_mtu #2411, net.ssh_keyscan #3556, …).
 register_typed_op_registrar(register_net_typed_operations)
 register_typed_op_registrar(register_net_tls_inspect_operation)
 register_typed_op_registrar(register_net_http_probe_operations)
 register_typed_op_registrar(register_net_ntp_check_operation)
 register_typed_op_registrar(register_net_icmp_operations)
+register_typed_op_registrar(register_net_ssh_keyscan_operation)
 
 __all__ = [
     "register_net_http_probe_operations",
     "register_net_icmp_operations",
     "register_net_ntp_check_operation",
+    "register_net_ssh_keyscan_operation",
     "register_net_tls_inspect_operation",
     "register_net_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/net/ssh_keyscan.py
+++ b/backend/src/meho_backplane/connectors/net/ssh_keyscan.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Network-diagnostics typed op ``net.ssh_keyscan`` + its registrar.
+
+A ``net.*`` sibling probe on the T1 keystone (``net.tcp_check``). It
+performs an ``ssh-keyscan``-parity read: open the SSH transport
+**handshake** to ``host:port`` — key exchange only, **no
+authentication** and **no application bytes** — read the server's
+presented host key(s), and return each key's type, base64 blob, SHA256
+(and legacy MD5) fingerprint, and a ready-to-paste OpenSSH
+``known_hosts`` line, plus the joined ``known_hosts`` block.
+
+**Why this op exists.** ``SshConnector`` verifies host keys fail-closed:
+an SSH-transport target with no ``known_hosts`` pin in its Vault secret
+refuses to connect at all (see
+:mod:`meho_backplane.connectors.adapters.ssh`). Before this op the only
+way to obtain that pin was to run ``ssh-keyscan`` on an operator shell
+with direct reach to the target — an out-of-band, ungoverned step. This
+op mints the pin **through the backplane**, on the same policy / audit /
+broadcast dispatch path every operation uses. Like ``ssh-keyscan`` it
+trusts whoever answers on the wire, so the ``sha256_fingerprint`` must be
+verified out-of-band before the pin is trusted; the ``note`` field says so.
+
+**Why asyncssh, not a second SSH library.** asyncssh is already the
+backplane's SSH transport (every SSH-based connector inherits
+:class:`~meho_backplane.connectors.adapters.ssh.SshConnector`), and it
+exposes :func:`asyncssh.get_server_host_key` — a coroutine that connects,
+completes the SSH handshake, and returns the server host key it
+presented **without authenticating and without verifying** it. That is
+exactly the keyscan primitive, native-async, no new dependency, and no
+credential ever offered. Restricting ``server_host_key_algs`` to one key
+type per call yields that type's host key (the transport negotiates a
+single host key per connection), so one handshake per requested type
+collects the full set — the same shape ``ssh-keyscan`` uses.
+
+This op inherits the three keystone foundations verbatim:
+
+* **Probe allowlist** — :func:`~meho_backplane.connectors.net.allowlist.assert_probe_allowed`
+  screens the dialed ``host`` *before* any socket opens
+  (``MEHO_NETDIAG_PROBE_ALLOWLIST`` empty ⇒ every probe refused). A
+  refusal propagates to the dispatcher's ``connector_probe_refused``
+  arm (the same shape as ``net.tls_inspect``) instead of being reported
+  as a failed scan.
+* **Audit-visible host:port** — the return dict carries the literal
+  ``host``/``port`` (a host:port is not a secret), so the durable audit
+  row's ``raw_payload`` answers "who scanned what".
+* **Return-failures contract** — a refused, timed-out, DNS-failed, or
+  no-host-key endpoint is the **product**, not an error: the handler
+  returns ``{"scanned": false, "reason": <code>, ...}`` with dispatch
+  ``status="ok"``. It never raises a ``connector_*`` error for a scan
+  that ran. An allowlist refusal is the deliberate exception: nothing was
+  dialed, so it fails the dispatch instead.
+
+``safety_level="safe"`` + ``requires_approval=False``: a read-only
+handshake that offers no credential and sends no application data, so the
+probe allowlist is the sole floor (same posture as ``net.tls_inspect``).
+The presented host key is **public** material — never a private key —
+safe to log, audit, and hand to an agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import TYPE_CHECKING, Any, Final
+
+import asyncssh
+
+from meho_backplane.connectors.net.allowlist import assert_probe_allowed
+
+# Reuse the shared probe timeout bounds/clamp from the keystone module.
+# ``ops`` never imports this module (the __init__ queues each registrar
+# independently), so this package-internal import forms no cycle.
+from meho_backplane.connectors.net.ops import (
+    _DEFAULT_TIMEOUT_SECONDS,
+    _MAX_TIMEOUT_SECONDS,
+    _clamp_timeout,
+)
+from meho_backplane.operations.typed_register import register_typed_operation
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "NET_SSH_KEYSCAN_PARAMETER_SCHEMA",
+    "net_ssh_keyscan",
+    "register_net_ssh_keyscan_operation",
+]
+
+#: The default SSH port. A ``known_hosts`` entry omits the port for 22 and
+#: uses the ``[host]:port`` form otherwise (OpenSSH convention).
+_DEFAULT_SSH_PORT: Final[int] = 22
+
+#: Canonical host-key type → the ``server_host_key_algs`` set to request
+#: for it. The value is the ``known_hosts`` key type exactly as
+#: ``asyncssh`` reports it via ``key.get_algorithm()`` / the OpenSSH
+#: export prefix. RSA maps to the SHA-2 signature variants **and** the
+#: legacy ``ssh-rsa`` name: a modern server disables the SHA-1 ``ssh-rsa``
+#: signature algorithm by default (OpenSSH 8.8+) but still serves an RSA
+#: **host key** negotiated via ``rsa-sha2-256`` / ``-512`` — asyncssh
+#: returns that host key with ``get_algorithm() == "ssh-rsa"`` regardless,
+#: so requesting the whole family robustly collects the RSA host key.
+_KEY_TYPE_ALGOS: Final[dict[str, tuple[str, ...]]] = {
+    "ssh-ed25519": ("ssh-ed25519",),
+    "ecdsa-sha2-nistp256": ("ecdsa-sha2-nistp256",),
+    "ecdsa-sha2-nistp384": ("ecdsa-sha2-nistp384",),
+    "ecdsa-sha2-nistp521": ("ecdsa-sha2-nistp521",),
+    "ssh-rsa": ("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"),
+}
+
+#: The default set of host-key types to scan when the caller omits
+#: ``key_types`` — the modern types in a stable preference order (RSA
+#: last). Each is fetched with its own handshake.
+_DEFAULT_KEY_TYPES: Final[tuple[str, ...]] = (
+    "ssh-ed25519",
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+    "ssh-rsa",
+)
+
+#: Operator guidance surfaced verbatim in every result's ``note`` field.
+_NOTE: Final[str] = (
+    "SSH host public keys (public handshake material — never a private "
+    "key). To pin a linux-ssh (or any SSH-transport) target, patch its "
+    "Vault secret so the known_hosts field holds these lines, e.g. "
+    "`vault kv patch <secret_ref> known_hosts=<known_hosts>`; SshConnector "
+    "then verifies the host key fail-closed on every connect. Like "
+    "ssh-keyscan, this trusts whoever answers on the wire, so verify each "
+    "sha256_fingerprint against an out-of-band source of truth before you "
+    "pin it."
+)
+
+NET_SSH_KEYSCAN_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Hostname or IP literal to scan for SSH host keys. Must be "
+                "covered by MEHO_NETDIAG_PROBE_ALLOWLIST or the probe is "
+                "refused before any socket opens."
+            ),
+        },
+        "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "SSH port to open the transport handshake to (default 22).",
+        },
+        "timeout_seconds": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "maximum": _MAX_TIMEOUT_SECONDS,
+            "description": (
+                "Per-key-type handshake timeout in seconds (default 5, max "
+                "30). A handshake that does not complete in time returns "
+                "scanned=false with reason='timeout'."
+            ),
+        },
+        "key_types": {
+            "type": "array",
+            "items": {"type": "string", "enum": list(_KEY_TYPE_ALGOS)},
+            "minItems": 1,
+            "uniqueItems": True,
+            "description": (
+                "Optional list of host-key types to fetch (one handshake "
+                "each). Omit to scan all common types "
+                "(ssh-ed25519, ecdsa-sha2-nistp256/384/521, ssh-rsa)."
+            ),
+        },
+    },
+    "required": ["host"],
+    "additionalProperties": False,
+}
+
+_KEY_ITEM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": (
+                "Host-key type as it appears in a known_hosts line "
+                "(e.g. ssh-ed25519, ecdsa-sha2-nistp256, ssh-rsa)."
+            ),
+        },
+        "base64": {
+            "type": "string",
+            "description": "The host key blob, base64-encoded (the third known_hosts field).",
+        },
+        "sha256_fingerprint": {
+            "type": "string",
+            "description": (
+                "OpenSSH SHA256 fingerprint (SHA256:<base64>) — verify this "
+                "out-of-band before trusting the pin."
+            ),
+        },
+        "md5_fingerprint": {
+            "type": "string",
+            "description": (
+                "OpenSSH legacy MD5 fingerprint (MD5:aa:bb:...); ssh-keyscan -E md5 parity."
+            ),
+        },
+        "known_hosts_line": {
+            "type": "string",
+            "description": (
+                "A single ready-to-pin OpenSSH known_hosts line for this "
+                "key: '<host> <type> <base64>' (host is '[host]:port' when "
+                "port is not 22)."
+            ),
+        },
+    },
+    "required": ["type", "base64", "sha256_fingerprint", "md5_fingerprint", "known_hosts_line"],
+    "additionalProperties": False,
+}
+
+_NET_SSH_KEYSCAN_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "scanned": {
+            "type": "boolean",
+            "description": "True iff at least one host key was collected.",
+        },
+        "reason": {
+            "type": ["string", "null"],
+            "description": (
+                "Null on success; otherwise a failure code: timeout, "
+                "refused, dns_failure, unreachable, no_host_key. A host "
+                "outside MEHO_NETDIAG_PROBE_ALLOWLIST is not reported here — "
+                "it fails the dispatch with connector_probe_refused."
+            ),
+        },
+        "host": {"type": "string", "description": "The scanned host (audit-visible)."},
+        "port": {"type": "integer", "description": "The scanned port (audit-visible)."},
+        "keys": {
+            "type": "array",
+            "items": _KEY_ITEM_SCHEMA,
+            "description": "Collected host keys, one per negotiated type (empty on any failure).",
+        },
+        "known_hosts": {
+            "type": "string",
+            "description": (
+                "All collected known_hosts lines joined by newlines — paste "
+                "verbatim into a target's Vault secret as known_hosts. "
+                "Empty on any failure."
+            ),
+        },
+        "note": {
+            "type": "string",
+            "description": (
+                "Operator guidance on how to pin the result and the verify-out-of-band caveat."
+            ),
+        },
+    },
+    "required": ["scanned", "reason", "host", "port", "keys", "known_hosts", "note"],
+    "additionalProperties": False,
+}
+
+_NET_SSH_KEYSCAN_WHEN_TO_USE = (
+    "Fetch an SSH server's host key(s) to pin a target — the "
+    "'ssh-keyscan' read: 'what host key does this box present so I can "
+    "pin it in known_hosts?'. SshConnector verifies host keys "
+    "fail-closed, so an SSH-transport target with no known_hosts pin "
+    "cannot be dialed; this op mints that pin through the backplane "
+    "instead of an out-of-band shell ssh-keyscan. It opens the SSH "
+    "handshake (key exchange only — no login, no credentials, no "
+    "application bytes) and returns each key's type, base64, SHA256 "
+    "fingerprint, and a ready-to-paste known_hosts line. A refused, "
+    "timed-out, or non-SSH endpoint is a normal result, not an error. "
+    "The destination must be inside MEHO_NETDIAG_PROBE_ALLOWLIST; one "
+    "that is not fails with connector_probe_refused rather than reporting "
+    "a (false) empty scan."
+)
+
+_NET_SSH_KEYSCAN_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Use to obtain a target's SSH host-key pin (known_hosts lines + "
+        "SHA256 fingerprints) before registering or first dialing an "
+        "SSH-transport target, since host-key verification is fail-closed "
+        "without a pin. Read-only: no credential is offered and no "
+        "application bytes are sent — only the SSH key exchange runs."
+    ),
+    "parameter_hints": {
+        "host": "Required. Hostname or IP literal. Must be allowlisted for probing.",
+        "port": "Optional. SSH port (default 22).",
+        "timeout_seconds": "Optional. Per-key-type handshake timeout (default 5, max 30).",
+        "key_types": (
+            "Optional. Host-key types to fetch (ssh-ed25519, "
+            "ecdsa-sha2-nistp256/384/521, ssh-rsa). Omit to scan all."
+        ),
+    },
+    "output_shape": (
+        "On success: {'scanned': true, 'reason': null, 'keys': [{'type', "
+        "'base64', 'sha256_fingerprint', 'md5_fingerprint', "
+        "'known_hosts_line'}, ...], 'known_hosts': '<lines joined>', "
+        "'note': <pin-flow guidance>, 'host', 'port'}. Pin flow: patch the "
+        "target's Vault secret with known_hosts=<the known_hosts field> "
+        "(e.g. via a vault kv patch), which SshConnector enforces "
+        "fail-closed. On a refused / timed-out / non-SSH endpoint: the same "
+        "keys with scanned=false, reason set, keys=[] and known_hosts='' — "
+        "still a successful (status=ok) op. A host outside "
+        "MEHO_NETDIAG_PROBE_ALLOWLIST is NOT a reading: the op fails with "
+        "error_code='connector_probe_refused' and no socket was opened."
+    ),
+}
+
+
+def _resolve_key_types(raw: Any) -> tuple[str, ...]:
+    """Return the ordered, de-duplicated set of host-key types to scan.
+
+    A missing / empty ``key_types`` yields :data:`_DEFAULT_KEY_TYPES`. A
+    caller-supplied list is filtered to the known types (the schema enum
+    already enforces this on the dispatch path; the filter keeps a direct
+    handler call bounded too) and de-duplicated while preserving order.
+    """
+    if not raw:
+        return _DEFAULT_KEY_TYPES
+    seen: set[str] = set()
+    resolved: list[str] = []
+    for item in raw:
+        key = str(item)
+        if key in _KEY_TYPE_ALGOS and key not in seen:
+            seen.add(key)
+            resolved.append(key)
+    return tuple(resolved) if resolved else _DEFAULT_KEY_TYPES
+
+
+def _known_hosts_line(host: str, port: int, key_type: str, key_b64: str) -> str:
+    """Build one OpenSSH known_hosts line for *host*.
+
+    OpenSSH omits the port for the default 22 (``host type base64``) and
+    uses the bracketed ``[host]:port`` form otherwise — the shape
+    ``asyncssh.import_known_hosts`` (which ``SshConnector`` parses the pin
+    with) matches against the dialed host:port.
+    """
+    host_field = host if port == _DEFAULT_SSH_PORT else f"[{host}]:{port}"
+    return f"{host_field} {key_type} {key_b64}"
+
+
+def _key_entry(host: str, port: int, key: asyncssh.SSHKey) -> dict[str, Any]:
+    """Flatten one presented host key into the audit-safe report shape.
+
+    The OpenSSH export (``<type> <base64>[ <comment>]``) supplies both the
+    known_hosts key type and the base64 blob; the SHA256 / MD5 fingerprints
+    come from asyncssh's ``get_fingerprint`` (already in the exact OpenSSH
+    ``SHA256:<base64>`` / ``MD5:aa:bb:..`` form). No private material is
+    ever touched — a host key is public handshake material.
+    """
+    type_and_b64 = key.export_public_key("openssh").decode("ascii").split()
+    key_type = type_and_b64[0]
+    key_b64 = type_and_b64[1]
+    return {
+        "type": key_type,
+        "base64": key_b64,
+        "sha256_fingerprint": key.get_fingerprint("sha256"),
+        "md5_fingerprint": key.get_fingerprint("md5"),
+        "known_hosts_line": _known_hosts_line(host, port, key_type, key_b64),
+    }
+
+
+def _result(host: str, port: int, keys: list[dict[str, Any]], reason: str | None) -> dict[str, Any]:
+    """Assemble the uniform response payload (success or failure)."""
+    return {
+        "scanned": bool(keys),
+        "reason": reason,
+        "host": host,
+        "port": port,
+        "keys": keys,
+        "known_hosts": "\n".join(entry["known_hosts_line"] for entry in keys),
+        "note": _NOTE,
+    }
+
+
+async def net_ssh_keyscan(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Fetch the SSH host key(s) ``host:port`` presents, without authenticating.
+
+    Op-id: ``net.ssh_keyscan``. Synthetic typed op (``target`` is always
+    ``None``); the dispatcher has validated the schema. Flow: screen
+    ``host`` against the probe allowlist → for each requested key type run
+    :func:`asyncssh.get_server_host_key` (SSH handshake only — no auth, no
+    application bytes, no host-key verification) under
+    :func:`asyncio.wait_for` → flatten each presented key to its type /
+    base64 / fingerprints / known_hosts line.
+
+    A server that offers no host key of a requested type raises
+    :exc:`asyncssh.KeyExchangeFailed`, which is caught per type and skipped
+    (the next type is still tried). A refused / timed-out / DNS-failed /
+    otherwise-unreachable endpoint returns ``scanned=false`` with a reason
+    code and ``status="ok"`` (the return-failures contract), and a
+    connect-level failure short-circuits the remaining types so the whole
+    op stays bounded. When the handshake succeeds but no requested type is
+    available, ``reason="no_host_key"``. An allowlist refusal is the
+    exception: nothing was dialed, so :exc:`ProbeNotAllowedError`
+    propagates to the dispatcher's ``connector_probe_refused`` arm. The
+    return dict carries the literal ``host``/``port`` for the durable audit
+    row.
+    """
+    host = str(params["host"])
+    port = int(params.get("port", _DEFAULT_SSH_PORT))
+    timeout = _clamp_timeout(params.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS))
+    key_types = _resolve_key_types(params.get("key_types"))
+
+    assert_probe_allowed(host, tenant_id=operator.tenant_id)
+
+    keys: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    connect_reason: str | None = None
+    for key_type in key_types:
+        try:
+            key = await asyncio.wait_for(
+                asyncssh.get_server_host_key(
+                    host, port=port, server_host_key_algs=list(_KEY_TYPE_ALGOS[key_type])
+                ),
+                timeout=timeout,
+            )
+        except asyncssh.KeyExchangeFailed:
+            # Connected, but the server presents no host key of this type.
+            # Skip it and try the next requested type — not a failure yet.
+            continue
+        except TimeoutError:
+            # asyncio.wait_for raises builtin TimeoutError on timeout (== asyncio.TimeoutError).
+            # Caught before OSError below since TimeoutError subclasses OSError.
+            connect_reason = "timeout"
+            break
+        except socket.gaierror:
+            # DNS resolution failed (also an OSError subclass — catch first).
+            connect_reason = "dns_failure"
+            break
+        except ConnectionRefusedError:
+            connect_reason = "refused"
+            break
+        except (OSError, asyncssh.Error):
+            # Network/host unreachable, reset by a non-SSH peer, protocol
+            # error, etc. asyncssh.Error is not an OSError, so both bases
+            # are caught here; KeyExchangeFailed was already handled above.
+            connect_reason = "unreachable"
+            break
+        if key is None:
+            continue
+        entry = _key_entry(host, port, key)
+        dedup = (entry["type"], entry["base64"])
+        if dedup in seen:
+            continue
+        seen.add(dedup)
+        keys.append(entry)
+
+    if keys:
+        # We collected at least one key; a connect-level error on a later
+        # type does not undo a successful scan.
+        return _result(host, port, keys, None)
+    # Connected but no requested type was available ⇒ no_host_key; otherwise
+    # the connect-level reason from the first failed handshake.
+    return _result(host, port, keys, connect_reason or "no_host_key")
+
+
+async def register_net_ssh_keyscan_operation(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the ``net.ssh_keyscan`` typed op into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list by the package
+    ``__init__`` (a sibling registrar to ``net.tcp_check``'s), run after
+    the connector eager-import pass. Registered under the same synthetic
+    natural key as the keystone
+    (``product="net", version="1.x", impl_id="net-probe"``), so it shares
+    the ``net-probe-1.x`` wire ``connector_id``. Idempotent. ``safe`` +
+    ``requires_approval=False`` — the probe allowlist is the only floor.
+    """
+    await register_typed_operation(
+        product="net",
+        version="1.x",
+        impl_id="net-probe",
+        op_id="net.ssh_keyscan",
+        handler=net_ssh_keyscan,
+        group_key="probe",
+        when_to_use=_NET_SSH_KEYSCAN_WHEN_TO_USE,
+        summary="Fetch an SSH server's host key(s) to pin a target — ssh-keyscan parity.",
+        description=(
+            "Opens the SSH transport handshake to a host:port — key "
+            "exchange only, no authentication, no credentials, and no "
+            "application bytes — reads the server's presented host key(s), "
+            "and returns each key's type, base64 blob, SHA256 and legacy "
+            "MD5 fingerprint, and a ready-to-paste OpenSSH known_hosts "
+            "line, plus the joined known_hosts block. It mints the "
+            "host-key pin SshConnector's fail-closed verification requires, "
+            "through the backplane instead of an out-of-band shell "
+            "ssh-keyscan. The presented host key is public material, never "
+            "a private key. The destination must be inside "
+            "MEHO_NETDIAG_PROBE_ALLOWLIST or the probe is refused before "
+            "any socket opens, which fails the dispatch with "
+            "connector_probe_refused. A refused, timed-out, DNS-failed, or "
+            "non-SSH endpoint returns scanned=false with a reason code and "
+            "status=ok — a failed scan is the product, never a connector "
+            "error. Like ssh-keyscan it trusts whoever answers, so verify "
+            "the sha256_fingerprint out-of-band before pinning."
+        ),
+        parameter_schema=NET_SSH_KEYSCAN_PARAMETER_SCHEMA,
+        response_schema=_NET_SSH_KEYSCAN_RESPONSE_SCHEMA,
+        tags=["net", "probe", "read", "diagnostics", "ssh"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_NET_SSH_KEYSCAN_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/tests/test_connectors_net_ssh_keyscan.py
+++ b/backend/tests/test_connectors_net_ssh_keyscan.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for ``net.ssh_keyscan`` — SSH host-key pin, ssh-keyscan parity (#3556).
+
+A ``net.*`` sibling probe on the T1 keystone. Covers:
+
+* The op fetches the server's presented host key(s) over the SSH
+  handshake **without authenticating** — a real in-process asyncssh
+  server presenting an ed25519 **and** an RSA host key is scanned over
+  loopback and both are returned, leaf shape complete.
+* The returned ``known_hosts`` block round-trips through
+  ``asyncssh.import_known_hosts`` and pins the server's actual host key
+  (fingerprint identity) — the probe → pin loop #3467's fail-closed
+  verification requires.
+* ``key_types`` scopes the scan; a server offering none of the requested
+  types yields ``scanned=false`` / ``reason="no_host_key"`` (status ok).
+* ``host`` is probe-allowlist-gated (T1 foundation); an un-allowlisted
+  host fails the dispatch with ``connector_probe_refused`` before any
+  socket opens — the ``net.tls_inspect`` refusal shape.
+* The return-failures contract: refused / timeout / DNS / unreachable
+  return ``scanned=false`` with a reason code and ``status="ok"``.
+* The audit row records the literal ``host``/``port``; the op registers
+  ``safe`` + ungated; ``net.ssh_keyscan`` classifies as ``read``.
+
+The SSH server runs in-process on the same event loop; the handler dials
+it over loopback (added to ``MEHO_NETDIAG_PROBE_ALLOWLIST``).
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import asyncssh
+import pytest
+from jsonschema import Draft202012Validator
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.net import ssh_keyscan as net_ssh
+from meho_backplane.connectors.net.allowlist import PROBE_ALLOWLIST_ENV
+from meho_backplane.connectors.net.ssh_keyscan import (
+    net_ssh_keyscan,
+    register_net_ssh_keyscan_operation,
+)
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "net-probe-1.x"
+_OP_ID = "net.ssh_keyscan"
+
+
+# ---------------------------------------------------------------------------
+# Settings env + dispatcher isolation (mirrors the sibling probe modules)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.delenv(PROBE_ALLOWLIST_ENV, raising=False)
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_ssh_keyscan_op(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    await register_net_ssh_keyscan_operation(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt="fake.jwt.value",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_scan(params: dict[str, Any]) -> OperationResult:
+    return await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=None,
+        params=params,
+    )
+
+
+# ---------------------------------------------------------------------------
+# In-process SSH server test double
+# ---------------------------------------------------------------------------
+
+
+class _NoAuthServer(asyncssh.SSHServer):
+    """An SSH server that needs no authentication (irrelevant to a keyscan).
+
+    ``get_server_host_key`` disconnects right after the key exchange and
+    never authenticates, so this only has to complete the handshake and
+    present its host keys.
+    """
+
+    def begin_auth(self, username: str) -> bool:
+        return False
+
+
+async def _start_ssh_server(
+    tmp_path: Path, host_key_algs: list[str]
+) -> tuple[asyncssh.SSHAcceptor, int, dict[str, asyncssh.SSHKey]]:
+    """Start a loopback SSH server presenting one host key per *host_key_algs*.
+
+    Returns ``(acceptor, port, {alg: public_key})`` so a test can assert
+    fingerprint identity against exactly what the server serves.
+    """
+    key_paths: list[str] = []
+    public_by_alg: dict[str, asyncssh.SSHKey] = {}
+    for i, alg in enumerate(host_key_algs):
+        key = (
+            asyncssh.generate_private_key(alg, key_size=2048)
+            if alg == "ssh-rsa"
+            else asyncssh.generate_private_key(alg)
+        )
+        path = tmp_path / f"host_key_{i}"
+        key.write_private_key(str(path))
+        key_paths.append(str(path))
+        public_by_alg[alg] = key.convert_to_public()
+    acceptor = await asyncssh.create_server(
+        _NoAuthServer, "127.0.0.1", 0, server_host_keys=key_paths
+    )
+    port = acceptor.sockets[0].getsockname()[1]
+    return acceptor, port, public_by_alg
+
+
+# ---------------------------------------------------------------------------
+# Full scan — multiple key types, real handshake, fresh boot
+# ---------------------------------------------------------------------------
+
+
+async def test_scans_multiple_host_key_types(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    """A server presenting ed25519 + RSA yields both keys, correctly shaped."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    acceptor, port, _publics = await _start_ssh_server(tmp_path, ["ssh-ed25519", "ssh-rsa"])
+    try:
+        result = await _dispatch_scan({"host": "127.0.0.1", "port": port})
+    finally:
+        acceptor.close()
+        await acceptor.wait_closed()
+
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["scanned"] is True
+    assert body["reason"] is None
+    types = {k["type"] for k in body["keys"]}
+    assert types == {"ssh-ed25519", "ssh-rsa"}
+    for entry in body["keys"]:
+        assert entry["base64"]
+        assert entry["sha256_fingerprint"].startswith("SHA256:")
+        assert entry["md5_fingerprint"].startswith("MD5:")
+        # The known_hosts line is '<host-field> <type> <base64>'; the
+        # loopback server is on a non-22 port, so the bracketed form.
+        assert entry["known_hosts_line"] == f"[127.0.0.1]:{port} {entry['type']} {entry['base64']}"
+    # The joined block contains one line per collected key.
+    assert body["known_hosts"].splitlines() == [k["known_hosts_line"] for k in body["keys"]]
+    assert "vault kv patch" in body["note"]
+
+
+async def test_known_hosts_block_pins_the_actual_server_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    """The returned known_hosts round-trips and matches the served host keys.
+
+    This is the probe -> pin loop the fail-closed SshConnector needs: the
+    ``known_hosts`` block parses via ``asyncssh.import_known_hosts`` and each
+    scanned key's SHA256 fingerprint equals the fingerprint of the key the
+    server actually presented.
+    """
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    acceptor, port, publics = await _start_ssh_server(tmp_path, ["ssh-ed25519", "ssh-rsa"])
+    try:
+        result = await _dispatch_scan({"host": "127.0.0.1", "port": port})
+    finally:
+        acceptor.close()
+        await acceptor.wait_closed()
+    assert result.status == "ok", result.error
+    body = result.result
+
+    # Parses as a real known_hosts store (the exact shape SshConnector pins).
+    known_hosts = asyncssh.import_known_hosts(body["known_hosts"])
+    assert known_hosts is not None
+
+    # Each scanned key's fingerprint equals the served key's fingerprint.
+    by_type = {k["type"]: k for k in body["keys"]}
+    for alg, public in publics.items():
+        assert by_type[alg]["sha256_fingerprint"] == public.get_fingerprint("sha256")
+        # base64 is the exact blob the server presented (identity, not shape).
+        assert by_type[alg]["base64"] == public.export_public_key("openssh").decode().split()[1]
+
+
+async def test_key_types_param_scopes_the_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    """``key_types`` restricts which host-key types are fetched."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    acceptor, port, _ = await _start_ssh_server(tmp_path, ["ssh-ed25519", "ssh-rsa"])
+    try:
+        result = await _dispatch_scan(
+            {"host": "127.0.0.1", "port": port, "key_types": ["ssh-ed25519"]}
+        )
+    finally:
+        acceptor.close()
+        await acceptor.wait_closed()
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["scanned"] is True
+    assert [k["type"] for k in body["keys"]] == ["ssh-ed25519"]
+
+
+async def test_no_host_key_when_server_offers_none_of_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    """A server without any requested type ⇒ scanned=false / no_host_key, status ok."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    # Server presents only ed25519; ask for RSA.
+    acceptor, port, _ = await _start_ssh_server(tmp_path, ["ssh-ed25519"])
+    try:
+        result = await _dispatch_scan({"host": "127.0.0.1", "port": port, "key_types": ["ssh-rsa"]})
+    finally:
+        acceptor.close()
+        await acceptor.wait_closed()
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["scanned"] is False
+    assert body["reason"] == "no_host_key"
+    assert body["keys"] == []
+    assert body["known_hosts"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Probe allowlist (T1 foundation) + audit row records host:port
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_allowlist_refuses_before_any_socket_opens(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    """Empty allowlist ⇒ structured refusal, no handshake attempted."""
+
+    async def _boom(*_a: object, **_kw: object) -> object:
+        raise AssertionError("get_server_host_key must not run when the probe is refused")
+
+    monkeypatch.setattr(net_ssh.asyncssh, "get_server_host_key", _boom)
+    result = await _dispatch_scan({"host": "10.1.2.3", "port": 22})
+    assert result.status == "error"
+    assert result.result is None
+    assert result.extras["error_code"] == "connector_probe_refused"
+    assert result.extras["host"] == "10.1.2.3"
+    assert result.error is not None
+    assert PROBE_ALLOWLIST_ENV in result.error
+
+
+async def test_audit_row_records_literal_host_and_port(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    acceptor, port, _ = await _start_ssh_server(tmp_path, ["ssh-ed25519"])
+    try:
+        result = await _dispatch_scan({"host": "127.0.0.1", "port": port})
+    finally:
+        acceptor.close()
+        await acceptor.wait_closed()
+    assert result.status == "ok", result.error
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = list(
+            (await session.execute(select(AuditLog).where(AuditLog.path == _OP_ID))).scalars().all()
+        )
+    assert len(rows) == 1
+    raw = rows[0].raw_payload
+    assert raw is not None
+    assert raw["host"] == "127.0.0.1"
+    assert raw["port"] == port
+
+
+# ---------------------------------------------------------------------------
+# Return-failures contract — a failed scan is status=ok, never connector_*
+# ---------------------------------------------------------------------------
+
+
+async def test_refused_connect_is_ok_status_not_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    """A closed port returns scanned=false / reason=refused, status=ok."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()  # port is now (almost certainly) closed
+
+    result = await _dispatch_scan({"host": "127.0.0.1", "port": port})
+    assert result.status == "ok", result.error
+    assert result.extras.get("exception_class") is None
+    assert result.result["scanned"] is False
+    assert result.result["reason"] == "refused"
+    assert result.result["keys"] == []
+
+
+@pytest.mark.parametrize(
+    "exc,expected_reason",
+    [
+        (TimeoutError(), "timeout"),
+        (socket.gaierror("name resolution failed"), "dns_failure"),
+        (ConnectionRefusedError(), "refused"),
+        (OSError("network is unreachable"), "unreachable"),
+        (asyncssh.Error(code=2, reason="protocol error"), "unreachable"),
+    ],
+    ids=["timeout", "gaierror", "refused", "other-oserror", "asyncssh-error"],
+)
+async def test_handler_maps_connect_exceptions_to_reason_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: BaseException,
+    expected_reason: str,
+) -> None:
+    """Every connect/handshake failure maps to a reason code, never re-raises."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "203.0.113.5")
+
+    async def _raise(*_a: object, **_kw: object) -> object:
+        raise exc
+
+    monkeypatch.setattr(net_ssh.asyncssh, "get_server_host_key", _raise)
+    result = await net_ssh_keyscan(_make_operator(), None, {"host": "203.0.113.5", "port": 22})
+    assert result["scanned"] is False
+    assert result["reason"] == expected_reason
+    assert result["host"] == "203.0.113.5"
+    assert result["port"] == 22
+    assert result["keys"] == []
+    assert result["known_hosts"] == ""
+
+
+async def test_key_exchange_failed_is_skipped_not_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-type KeyExchangeFailed skips that type; a later type still scans.
+
+    First requested type raises KeyExchangeFailed (server offers no such
+    type), the second returns a real key — the handler collects the second
+    rather than aborting on the first.
+    """
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "203.0.113.5")
+    good = asyncssh.generate_private_key("ssh-ed25519").convert_to_public()
+    calls: list[list[str]] = []
+
+    async def _fake(host: str, *, port: int, server_host_key_algs: list[str], **_kw: object):
+        calls.append(server_host_key_algs)
+        if "ssh-ed25519" in server_host_key_algs:
+            raise asyncssh.KeyExchangeFailed("no matching host key")
+        return good
+
+    monkeypatch.setattr(net_ssh.asyncssh, "get_server_host_key", _fake)
+    result = await net_ssh_keyscan(
+        _make_operator(),
+        None,
+        {"host": "203.0.113.5", "key_types": ["ssh-ed25519", "ssh-rsa"]},
+    )
+    assert result["scanned"] is True
+    assert [k["type"] for k in result["keys"]] == [good.get_algorithm()]
+    # Both types were attempted (the first was skipped, not fatal).
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Registration + classification + schema conformance
+# ---------------------------------------------------------------------------
+
+
+async def test_ssh_keyscan_registered_as_safe_ungated_typed_op(
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == "net",
+                    EndpointDescriptor.version == "1.x",
+                    EndpointDescriptor.impl_id == "net-probe",
+                    EndpointDescriptor.op_id == _OP_ID,
+                )
+            )
+        ).scalar_one()
+    assert row.source_kind == "typed"
+    assert row.safety_level == "safe"
+    assert row.requires_approval is False
+
+
+def test_ssh_keyscan_classifies_as_read() -> None:
+    from meho_backplane.broadcast.events import classify_op
+
+    assert classify_op("net.ssh_keyscan") == "read"
+
+
+async def test_success_and_failure_results_validate_against_response_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_ssh_keyscan_op: None,
+) -> None:
+    """Both a success and a failure body round-trip through the response schema."""
+    schema = net_ssh._NET_SSH_KEYSCAN_RESPONSE_SCHEMA
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    acceptor, port, _ = await _start_ssh_server(tmp_path, ["ssh-ed25519"])
+    try:
+        success = await _dispatch_scan({"host": "127.0.0.1", "port": port})
+    finally:
+        acceptor.close()
+        await acceptor.wait_closed()
+    assert success.status == "ok", success.error
+    validator.validate(success.result)
+
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    closed_port = probe.getsockname()[1]
+    probe.close()
+    failure = await _dispatch_scan({"host": "127.0.0.1", "port": closed_port})
+    assert failure.status == "ok", failure.error
+    assert failure.result["scanned"] is False
+    validator.validate(failure.result)
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_key_types_defaults_dedups_and_filters() -> None:
+    assert net_ssh._resolve_key_types(None) == net_ssh._DEFAULT_KEY_TYPES
+    assert net_ssh._resolve_key_types([]) == net_ssh._DEFAULT_KEY_TYPES
+    # De-duplicated, order preserved.
+    assert net_ssh._resolve_key_types(["ssh-rsa", "ssh-rsa", "ssh-ed25519"]) == (
+        "ssh-rsa",
+        "ssh-ed25519",
+    )
+    # Unknown entries are dropped; an all-unknown list falls back to defaults.
+    assert net_ssh._resolve_key_types(["bogus"]) == net_ssh._DEFAULT_KEY_TYPES
+
+
+def test_known_hosts_line_uses_bracket_form_only_for_non_default_port() -> None:
+    assert (
+        net_ssh._known_hosts_line("h.local", 22, "ssh-ed25519", "AAAA")
+        == "h.local ssh-ed25519 AAAA"
+    )
+    assert (
+        net_ssh._known_hosts_line("h.local", 2222, "ssh-ed25519", "AAAA")
+        == "[h.local]:2222 ssh-ed25519 AAAA"
+    )

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -16,16 +16,17 @@ module-level functions the dispatcher routes to with
 This page describes the keystone (#2406, Initiative #2405 T1):
 `net.tcp_check` plus the three foundations every sibling op reuses, and
 the sibling ops `net.tls_inspect` (#2407, T2), `net.http_probe` (#2408,
-T3), `net.dns_lookup` (#2409, T4), `net.ntp_check` (#2410, T5), and the
-ICMP cohort `net.ping` / `net.trace` / `net.path_mtu` (#2411, T6) built on
-that mold — all described below.
+T3), `net.dns_lookup` (#2409, T4), `net.ntp_check` (#2410, T5), the
+ICMP cohort `net.ping` / `net.trace` / `net.path_mtu` (#2411, T6), and
+`net.ssh_keyscan` (#3556) built on that mold — all described below.
 
 Each op queues a registrar in `__init__.py` via
 `register_typed_op_registrar` (`net.tcp_check` and `net.dns_lookup` share
 `ops.register_net_typed_operations`; `net.tls_inspect` →
 `tls.register_net_tls_inspect_operation`; `net.http_probe` →
 `http_probe.register_net_http_probe_operations`; `net.ntp_check` →
-`ntp.register_net_ntp_check_operation`). Siblings therefore extend the
+`ntp.register_net_ntp_check_operation`; `net.ssh_keyscan` →
+`ssh_keyscan.register_net_ssh_keyscan_operation`). Siblings therefore extend the
 package by adding (at most) a module and one registrar-queue line rather
 than contending for a single registrar function — which also keeps
 parallel task branches from colliding on one shared file.
@@ -433,6 +434,93 @@ also surfaces the 4-char `kiss_code` (e.g. `RATE`, `DENY`). None are
 raised as `connector_*` errors; the `host`/`port` in the return dict are
 audit-visible via `raw_payload`.
 
+## `net.ssh_keyscan` — SSH host-key pin, ssh-keyscan parity (#3556)
+
+`net.ssh_keyscan(host, port=22, timeout_seconds?, key_types?)` opens the
+SSH transport **handshake** to `host:port` — key exchange only, **no
+authentication**, **no credentials offered**, and **no application bytes
+sent** — reads the server's presented host key(s), and returns each key's
+type, base64 blob, SHA256 (and legacy MD5) fingerprint, and a
+ready-to-paste OpenSSH `known_hosts` line, plus the joined `known_hosts`
+block. `ssh-keyscan` parity.
+
+**Why it exists.** `SshConnector` verifies host keys **fail-closed**
+(#3467 / F08): an SSH-transport target (`linux-ssh`, bind9, pfSense, …)
+whose Vault secret pins no `known_hosts` value refuses to connect at all
+(see `docs/codebase/connectors-linux.md` and `adapters/ssh.py`). Before
+this op the only way to obtain that pin was to run `ssh-keyscan` on an
+operator shell with direct reach to the target — an out-of-band,
+ungoverned step, and the operator-helper gap #3532 tracks. This op mints
+the pin **through the backplane**, on the same policy / audit / broadcast
+dispatch path every operation uses, so bootstrapping a target's host-key
+trust never leaves the governed path.
+
+Lives in `connectors/net/ssh_keyscan.py` with its own registrar
+(`register_net_ssh_keyscan_operation`), queued alongside `net.tcp_check`'s
+in the package `__init__`. It reuses the same three foundations and the
+shared timeout bounds/clamp from `ops.py`.
+
+**Why asyncssh, not a second SSH library.** asyncssh is already the
+backplane's SSH transport (every SSH connector inherits `SshConnector`),
+and it exposes `asyncssh.get_server_host_key(host, port, *,
+server_host_key_algs=...)` — a coroutine that connects, completes the SSH
+handshake, and returns the server host key it presented **without
+authenticating and without verifying** it. That is exactly the keyscan
+primitive: native-async, no new dependency, and no credential ever
+offered. (paramiko's `Transport.get_remote_server_key()` would do the
+same, but it is a second SSH library and is LGPL — outside the Apache-2.0
+outbound license allow-list the dependency-license gate enforces, whereas
+asyncssh is already a vetted dependency.) Restricting
+`server_host_key_algs` to one key type per call yields that type's host
+key (the transport negotiates a single host key per connection), so
+**one handshake per requested key type** collects the full set — the same
+shape `ssh-keyscan` uses. asyncssh normalises the returned key's
+`get_algorithm()` to the base `known_hosts` type (`ssh-rsa` even when
+negotiated via `rsa-sha2-256`/`-512`), so the RSA request maps the whole
+SHA-2 signature family and robustly collects the RSA host key from a
+modern server that has disabled the SHA-1 `ssh-rsa` signature algorithm.
+
+Control flow (`connectors/net/ssh_keyscan.py`):
+
+1. `assert_probe_allowed(host)` — the T1 allowlist floor, before any
+   socket opens.
+2. For each requested key type (default: `ssh-ed25519`,
+   `ecdsa-sha2-nistp256/384/521`, `ssh-rsa`), `asyncssh.get_server_host_key`
+   under `asyncio.wait_for(timeout)`. A type the server does not present
+   raises `asyncssh.KeyExchangeFailed`, caught **per type** and skipped
+   (the next type is still tried). A connect-level failure (refused / DNS /
+   timeout / unreachable) short-circuits the remaining types so the whole
+   op stays bounded.
+3. Each presented key is flattened to `{type, base64, sha256_fingerprint,
+   md5_fingerprint, known_hosts_line}` — type + base64 from the key's
+   OpenSSH export, fingerprints from asyncssh's `get_fingerprint` (already
+   in the exact `SHA256:<base64>` / `MD5:aa:bb:..` OpenSSH form).
+   `known_hosts_line` is `<host> <type> <base64>`, with the OpenSSH
+   `[host]:port` form for a non-22 port.
+
+Result shape: `{scanned, reason, host, port, keys: [...], known_hosts,
+note}`. `known_hosts` is the joined ready-to-pin block; `note` explains
+the pin flow (`vault kv patch <secret_ref> known_hosts=<known_hosts>`,
+which `SshConnector` then enforces fail-closed) and the caveat that — like
+`ssh-keyscan` — the op trusts whoever answers on the wire, so each
+`sha256_fingerprint` must be verified against an out-of-band source before
+the pin is trusted. The presented host key is **public** handshake
+material (never a private key), safe to log, audit, and hand to an agent.
+
+**Return-failures:** a refused, timed-out, DNS-failed, or unreachable
+endpoint returns `{scanned: false, reason}` with `status="ok"` — reason
+codes `timeout` / `refused` / `dns_failure` / `unreachable`, plus
+`no_host_key` when the handshake succeeded but the server offered none of
+the requested key types (or the endpoint is not SSH). None are raised as
+`connector_*` errors. An allowlist refusal is the exception: nothing was
+dialed, so it fails the dispatch with `connector_probe_refused` — the same
+shape as `net.tls_inspect`. `host`/`port` in the return dict are
+audit-visible via `raw_payload`.
+
+It shares the `net-probe-1.x` identity, and is `safety_level="safe"` +
+`requires_approval=False`: a read-only handshake that offers no credential
+and sends no application data, so the probe allowlist is the sole floor.
+
 ## `net.tls_inspect` — full presented certificate chain (T2, #2407)
 
 `net.tls_inspect(host, port, server_name?, timeout_seconds?)` opens a TLS
@@ -698,6 +786,12 @@ connectors' ops.
   48-byte packet build/parse (`_build_request` / `_parse_reply`), the
   NTP-timestamp codec, the one-shot `_NtpClientProtocol`, and the
   registrar.
+- `connectors/net/ssh_keyscan.py` — `net_ssh_keyscan` handler, its
+  schemas, the key-type → `server_host_key_algs` map (`_KEY_TYPE_ALGOS`),
+  the per-key flatten (`_key_entry`) and `known_hosts`-line builder
+  (`_known_hosts_line`), and the registrar. Uses
+  `asyncssh.get_server_host_key` (the house SSH transport) for a no-auth
+  handshake per requested key type.
 - `connectors/net/icmp.py` — the `net_ping` / `net_trace` /
   `net_path_mtu` handlers, their schemas, the low-level errqueue / ICMP
   primitives (`_checksum`, `_build_echo_request`, `_parse_extended_err`,
@@ -755,6 +849,13 @@ audit row carrying the structured envelope in `payload.error`.
   (`asyncio`, `socket`, `select`, `struct`, `errno`, `os`, `time`) — no
   new runtime dependency. The Linux socket ABI constants the stdlib does
   not surface are pinned as module-level integers.
+- `net.ssh_keyscan`: **asyncssh** (already the backplane's SSH transport
+  dependency, used by every SSH connector via `SshConnector`) — used via
+  `asyncssh.get_server_host_key` for the no-auth handshake and the
+  `SSHKey` export / fingerprint accessors. No new runtime dependency, and
+  no second SSH library: paramiko (whose `Transport.get_remote_server_key`
+  would do the same) is LGPL and outside the Apache-2.0 outbound
+  dependency-license allow-list, whereas asyncssh is already vetted.
 
 ## Known issues / deferred
 
@@ -804,7 +905,9 @@ audit row carrying the structured envelope in `payload.error`.
 - Parent: Initiative #2405, Tasks #2406 (T1 `tcp_check`) + #2407 (T2
   `tls_inspect`) + #2408 (T3 `http_probe`) + #2409 (T4 `dns_lookup`) +
   #2410 (T5 `ntp_check`) + #2411 (T6 ICMP cohort
-  `ping`/`trace`/`path_mtu`). RFC 5905 (NTPv4) for the `ntp_check` packet
+  `ping`/`trace`/`path_mtu`). Later sibling: #3556 (`ssh_keyscan`) — the
+  governed host-key pin for #3467's fail-closed SSH host-key verification
+  (the #3532 operator-helper ask). RFC 5905 (NTPv4) for the `ntp_check` packet
   and offset/delay math. Mold: secret broker
   (`docs/codebase/connectors-secret-broker.md`). SSRF sibling:
   `docs/codebase/target-ssrf-guard.md`. Broadcast taxonomy:


### PR DESCRIPTION
## What

Adds a SAFE, credential-free typed op **`net.ssh_keyscan`** to the
synthetic `net-probe-1.x` network-diagnostics connector.

`net.ssh_keyscan(host, port=22, timeout_seconds=5, key_types?)` opens the
SSH transport **handshake** to `host:port` — key exchange only, **no
authentication**, **no credentials offered**, and **no application bytes
sent** — reads the server's presented host key(s), and returns:

- `keys[]`: per key `{type, base64, sha256_fingerprint, md5_fingerprint,
  known_hosts_line}`
- `known_hosts`: the joined, ready-to-pin OpenSSH block
- `note`: the pin flow and the verify-out-of-band caveat
- `scanned` / `reason` / `host` / `port` (the return-failures shape)

## Why

`SshConnector` verifies host keys **fail-closed** (#3467): an SSH-transport
target (`linux-ssh`, bind9, pfSense, …) whose Vault secret pins no
`known_hosts` value refuses to connect at all. Until now the only way to
mint that pin was to run `ssh-keyscan` on an operator shell with direct
reach to the target — an out-of-band, ungoverned step, and the
operator-helper gap #3532 tracks.

This op mints the pin **through the backplane**, on the same policy /
audit / broadcast dispatch path every operation uses, so bootstrapping a
target's host-key trust never leaves the governed path. The motivating
case: an island router VM stood up by a consumer pack with no post-deploy
config channel — its first governed reach is blocked purely because no
host-key pin exists yet, and there was no governed way to mint one.

Pin flow the result hands the operator:
`vault kv patch <secret_ref> known_hosts=<known_hosts>`, which
`SshConnector` then enforces fail-closed on every connect.

## Design notes

- **Reuses asyncssh, adds no dependency.** asyncssh is already the
  backplane's SSH transport for every SSH connector (via `SshConnector`).
  It exposes `asyncssh.get_server_host_key(host, port, *,
  server_host_key_algs=...)` — a coroutine that connects, completes the
  SSH handshake, and returns the server host key it presented **without
  authenticating and without verifying** it. That is exactly the keyscan
  primitive: native-async, no new dependency, no credential ever offered.
  One handshake per requested key type collects the full set (the
  transport negotiates a single host key per connection), the same shape
  `ssh-keyscan` uses.
  - The task brief suggested paramiko's `Transport.get_remote_server_key()`.
    I deliberately used asyncssh instead: paramiko is **LGPL-2.1**, outside
    the Apache-2.0 outbound allow-list the `Python License Check` required
    status enforces (it would fail CI, and admitting LGPL is a
    licensing-policy call), and it would add a **second** SSH library to a
    codebase that standardises on asyncssh. asyncssh yields identical
    behaviour and is already vetted.
- **Inherits the `net.*` family's three foundations verbatim:** the
  `MEHO_NETDIAG_PROBE_ALLOWLIST` probe allowlist (an un-allowlisted host
  fails the dispatch with `connector_probe_refused` — the `net.tls_inspect`
  refusal shape), the audit-visible `host`/`port`, and the return-failures
  contract (refused / timeout / DNS / unreachable / `no_host_key` return
  `scanned=false` with a reason code and `status="ok"`, never a
  `connector_*` error).
- `safety_level="safe"`, `requires_approval=False`, gated only by the
  probe allowlist (and its per-tenant bound). Classifies as `read`.
- The presented host key is **public** handshake material — never a
  private key.

## Tests

`backend/tests/test_connectors_net_ssh_keyscan.py` (18 tests):

- A real in-process asyncssh server presenting **ed25519 + RSA** host keys
  scanned over loopback — both returned, correctly shaped.
- The returned `known_hosts` block round-trips through
  `asyncssh.import_known_hosts` and each scanned key's SHA256 fingerprint
  equals the fingerprint of the key the server actually presented (the
  probe → pin loop).
- `key_types` scoping; `no_host_key` when the server offers none of the
  requested types; per-type `KeyExchangeFailed` skipped, not fatal.
- Allowlist refusal (no handshake attempted); connect-failure reason
  mapping (timeout / DNS / refused / unreachable / asyncssh error);
  non-default-port `[host]:port` known_hosts form.
- Response-schema conformance (success + failure); `safe` + ungated
  registration; broadcast classification; audit row records host:port.

The connector's existing conformance / metadata / drift coverage stays
green (`test_typed_connectors_metadata`, `test_reference_docs_drift`,
`test_operations_connector_probe_refused`, the sibling `net.*` suites).

Docs: `docs/codebase/connectors-net-diagnostics.md` documents the op, its
control flow, dependency posture, and the paramiko-vs-asyncssh rationale.

No CHANGELOG entry (per the code-PR / merge-queue convention; the changelog
bullet lands as a separate follow-up).

Closes #3556
Refs #3467 #3532

🤖 Generated with [Claude Code](https://claude.com/claude-code)
