### PR TITLE
feat(connectors): vmware_rest vm.nic.repoint can target a STANDARD portgroup

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1185,18 +1185,25 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
     _CompositeSpec(
         op_id="vmware.composite.vm.nic.repoint",
         handler=vm_nic_repoint_composite,
-        summary="Repoint a vNIC to a different distributed portgroup.",
+        summary="Repoint a vNIC onto a distributed or standard portgroup.",
         description=(
             "Reads the NIC's current backing + MAC via "
             "GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}, resolves the "
             "target portgroup by display name via "
-            "GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP (there "
-            "is no dedicated portgroup list resource), then PATCHes the NIC "
-            "backing to {type: DISTRIBUTED_PORTGROUP, network}. A name that "
-            "resolves to zero / many portgroups refuses the repoint "
-            "(status='not_found' / 'ambiguous') with no PATCH issued. The "
-            "from->to network pair is what the four-eyes reviewer needs. "
-            "Equivalent of 'govc vm.network.change'."
+            "GET:/vcenter/network?filter.types=<backing_type> (there is no "
+            "dedicated portgroup list resource), then PATCHes the NIC "
+            "backing to {type: backing_type, network}. backing_type is "
+            "DISTRIBUTED_PORTGROUP (default) or STANDARD_PORTGROUP -- the "
+            "latter moves a NIC onto a host-local standard-switch portgroup "
+            "(e.g. to repair a VM whose NIC landed on an L2 that cannot "
+            "reach its gateway). Standard portgroups are host-scoped, so a "
+            "name can match one moid per host (status='ambiguous'); pass an "
+            "explicit 'network' moid to pick one. An explicit 'network' moid "
+            "skips name resolution and is type-checked against backing_type "
+            "(status='invalid_request' on mismatch); a name matching zero "
+            "portgroups returns status='not_found'. No PATCH is issued on "
+            "any non-repointed status. The from->to network pair is what the "
+            "four-eyes reviewer needs. Equivalent of 'govc vm.network.change'."
         ),
         parameter_schema=VM_NIC_REPOINT_PARAMETER_SCHEMA,
         response_schema=VM_NIC_REPOINT_RESPONSE_SCHEMA,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -263,6 +263,11 @@ _OP_HOST_SOFTWARE_APPLY = "POST:/esx/settings/hosts/{host}/software?action=apply
 # row is ``{network (id), name, type}``. Mirrors ``_read._OP_LIST_NETWORK``.
 _OP_LIST_NETWORK = "GET:/vcenter/network"
 _NETWORK_TYPE_DISTRIBUTED_PORTGROUP = "DISTRIBUTED_PORTGROUP"
+# ``Network.Summary.type`` value for a host-scoped standard portgroup — the
+# ``filter.types`` value the standard-portgroup resolution reads (mirrors
+# ``_NIC_BACKING_STANDARD_PORTGROUP``, which is the same enum on the NIC
+# backing-spec side).
+_NETWORK_TYPE_STANDARD_PORTGROUP = "STANDARD_PORTGROUP"
 # ``Vcenter.Vm.Hardware.Ethernet.BackingSpec.type`` value for a standard
 # portgroup -- the default backing the NIC create / repoint specs target.
 _NIC_BACKING_STANDARD_PORTGROUP = "STANDARD_PORTGROUP"
@@ -6793,23 +6798,25 @@ async def _read_cdrom(
     return info if isinstance(info, dict) else None
 
 
-async def _resolve_distributed_portgroup(
+async def _resolve_portgroup_by_name(
     *,
     connector: VmwareRestConnector,
     target: Any,
     operator: Operator,
     portgroup_name: str,
+    network_type: str,
 ) -> tuple[str | None, str, list[dict[str, Any]]]:
-    """Resolve a distributed-portgroup display name to its network moid.
+    """Resolve a portgroup display name to its network moid, scoped to *network_type*.
 
-    Reads ``GET:/vcenter/network`` filtered to ``DISTRIBUTED_PORTGROUP`` +
-    the name (the #1602 fix -- there is no dedicated portgroup list
-    resource). Returns ``(network_moid, "ok", [])`` on a unique match,
-    ``(None, "not_found", [])`` on no match, or ``(None, "ambiguous",
-    candidates)`` when the name is not unique. Shared between the
-    ``vm.nic.repoint`` handler (dispatch time) and its preview builder
-    (#1608), so the reviewer sees the same portgroup the approved dispatch
-    will bind.
+    Reads ``GET:/vcenter/network`` filtered to *network_type*
+    (``DISTRIBUTED_PORTGROUP`` / ``STANDARD_PORTGROUP``) + the name (the
+    #1602 fix -- there is no dedicated portgroup list resource). Returns
+    ``(network_moid, "ok", [])`` on a unique match, ``(None, "not_found",
+    [])`` on no match, or ``(None, "ambiguous", candidates)`` when the name
+    is not unique. Standard portgroups are host-scoped, so one display name
+    routinely resolves to several ``Network`` moids (one per host) --
+    ``ambiguous`` is the expected, correct fail-closed outcome there, and
+    the caller resolves it with an explicit ``network`` moid.
     """
     listing = await _read_sub_op(
         connector,
@@ -6817,7 +6824,7 @@ async def _resolve_distributed_portgroup(
         operator,
         _OP_LIST_NETWORK,
         {
-            "filter.types": [_NETWORK_TYPE_DISTRIBUTED_PORTGROUP],
+            "filter.types": [network_type],
             "filter.names": [portgroup_name],
         },
     )
@@ -6835,6 +6842,69 @@ async def _resolve_distributed_portgroup(
     if not isinstance(network_moid, str):
         return None, "not_found", matches
     return network_moid, "ok", []
+
+
+async def _resolve_distributed_portgroup(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    portgroup_name: str,
+) -> tuple[str | None, str, list[dict[str, Any]]]:
+    """Resolve a *distributed*-portgroup display name to its network moid.
+
+    Thin ``DISTRIBUTED_PORTGROUP``-scoped wrapper over
+    :func:`_resolve_portgroup_by_name`, kept as the stable seam the
+    ``vm.nic.repoint`` preview builder imports (#1608) so the reviewer sees
+    the same portgroup the approved dispatch binds.
+    """
+    return await _resolve_portgroup_by_name(
+        connector=connector,
+        target=target,
+        operator=operator,
+        portgroup_name=portgroup_name,
+        network_type=_NETWORK_TYPE_DISTRIBUTED_PORTGROUP,
+    )
+
+
+async def _validate_network_moid(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    network_moid: str,
+    network_type: str,
+) -> tuple[dict[str, Any] | None, str]:
+    """Confirm an explicit ``Network`` moid exists and is of *network_type*.
+
+    Reads ``GET:/vcenter/network`` filtered to the moid (``filter.networks``)
+    -- the escape hatch for a host-scoped standard portgroup whose display
+    name is ambiguous across hosts. Returns ``(row, "ok")`` when the moid
+    resolves and its ``type`` matches, ``(None, "not_found")`` when no row
+    carries the moid, or ``(row, "type_mismatch")`` when it resolves but is
+    the wrong network kind for the requested backing.
+    """
+    listing = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_LIST_NETWORK,
+        {"filter.networks": [network_moid]},
+    )
+    rows = _unwrap_value(listing)
+    match = (
+        next(
+            (row for row in rows if isinstance(row, dict) and row.get("network") == network_moid),
+            None,
+        )
+        if isinstance(rows, list)
+        else None
+    )
+    if match is None:
+        return None, "not_found"
+    if match.get("type") != network_type:
+        return match, "type_mismatch"
+    return match, "ok"
 
 
 def _resize_requires_power_off(
@@ -7001,6 +7071,50 @@ async def vm_resize_composite(
     }
 
 
+async def _resolve_repoint_target(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    portgroup_name: str,
+    backing_type: str,
+    explicit_network: str | None,
+) -> tuple[str | None, str, list[dict[str, Any]], str]:
+    """Resolve the ``vm.nic.repoint`` target network moid + display name.
+
+    Returns ``(network_moid, resolution, candidates, resolved_name)`` where
+    resolution is ``ok`` / ``not_found`` / ``ambiguous`` / ``type_mismatch``.
+    When *explicit_network* is given, name resolution is skipped and the
+    moid is validated for existence + type-consistency with *backing_type*;
+    otherwise the name is resolved against ``GET:/vcenter/network`` scoped
+    to *backing_type*. Shared verbatim between the handler (dispatch time)
+    and its preview builder so the approval preview cannot drift from the
+    approved dispatch.
+    """
+    if explicit_network:
+        row, status = await _validate_network_moid(
+            connector=connector,
+            target=target,
+            operator=operator,
+            network_moid=explicit_network,
+            network_type=backing_type,
+        )
+        resolved_name = (row.get("name") if isinstance(row, dict) else None) or portgroup_name
+        if status == "ok":
+            return explicit_network, "ok", [], resolved_name
+        if status == "type_mismatch":
+            return None, "type_mismatch", ([row] if isinstance(row, dict) else []), resolved_name
+        return None, "not_found", [], resolved_name
+    network_moid, resolution, candidates = await _resolve_portgroup_by_name(
+        connector=connector,
+        target=target,
+        operator=operator,
+        portgroup_name=portgroup_name,
+        network_type=backing_type,
+    )
+    return network_moid, resolution, candidates, portgroup_name
+
+
 async def vm_nic_repoint_composite(
     *,
     operator: Operator,
@@ -7008,19 +7122,32 @@ async def vm_nic_repoint_composite(
     params: dict[str, Any],
     connector: VmwareRestConnector,
 ) -> dict[str, Any] | OperationResult:
-    """Repoint an existing vNIC to a different distributed portgroup.
+    """Repoint an existing vNIC onto a distributed or standard portgroup.
 
     Op-id: ``vmware.composite.vm.nic.repoint``. Reads the NIC's current
     backing + MAC via ``GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}``,
-    resolves the target portgroup by name via ``GET:/vcenter/network``
-    filtered to ``DISTRIBUTED_PORTGROUP`` (the #1602 fix -- no dedicated
-    portgroup list resource), then PATCHes the NIC backing. A name that
-    resolves to zero / many portgroups refuses the repoint
-    (``not_found`` / ``ambiguous``) with no PATCH issued.
+    resolves the target portgroup, then PATCHes the NIC backing to
+    ``{type: backing_type, network}`` (the same internal sub-op the
+    ``host.detach_from_vds`` fallback path uses).
+
+    ``backing_type`` (default ``DISTRIBUTED_PORTGROUP``, back-compatible)
+    picks the network kind. The name is resolved via ``GET:/vcenter/network``
+    filtered to that kind (the #1602 fix -- no dedicated portgroup list
+    resource). Standard portgroups are host-scoped, so one display name
+    routinely resolves to several ``Network`` moids (one per host); the
+    vCenter REST Automation API exposes no reliable VM->host mapping, so an
+    ambiguous name fails closed (``ambiguous``) and the operator supplies
+    the exact moid via ``network``. An explicit ``network`` moid skips name
+    resolution and is validated for type-consistency (``invalid_request``
+    on mismatch). A name matching zero portgroups returns ``not_found``.
+    No PATCH is issued on any non-``ok`` resolution.
     """
     vm_moid = params["vm"]
     nic_id = params["nic"]
     portgroup_name = params["portgroup_name"]
+    backing_type = params.get("backing_type", _NIC_BACKING_DISTRIBUTED_PORTGROUP)
+    network_param = params.get("network")
+    explicit_network = network_param if isinstance(network_param, str) and network_param else None
 
     nic_info = await _read_ethernet_nic(
         connector=connector, target=target, operator=operator, vm_moid=vm_moid, nic_id=nic_id
@@ -7028,29 +7155,59 @@ async def vm_nic_repoint_composite(
     mac_address = nic_info.get("mac_address") if nic_info else None
     current_backing = nic_info.get("backing") if nic_info else None
 
-    network_moid, resolution, candidates = await _resolve_distributed_portgroup(
-        connector=connector, target=target, operator=operator, portgroup_name=portgroup_name
+    network_moid, resolution, candidates, resolved_name = await _resolve_repoint_target(
+        connector=connector,
+        target=target,
+        operator=operator,
+        portgroup_name=portgroup_name,
+        backing_type=backing_type,
+        explicit_network=explicit_network,
     )
+    kind = "standard" if backing_type == _NIC_BACKING_STANDARD_PORTGROUP else "distributed"
     base = {
         "vm": vm_moid,
         "nic": nic_id,
         "mac_address": mac_address,
         "current_backing": current_backing,
-        "requested_backing": {"portgroup_id": network_moid, "portgroup_name": portgroup_name},
+        "requested_backing": {
+            "portgroup_id": network_moid,
+            "portgroup_name": resolved_name,
+            "backing_type": backing_type,
+        },
     }
     if resolution == "not_found":
-        return {
-            **base,
-            "status": "not_found",
-            "candidates": [],
-            "guidance": f"no distributed portgroup named {portgroup_name!r}",
-        }
+        guidance = (
+            f"network moid {explicit_network!r} not found"
+            if explicit_network
+            else f"no {kind} portgroup named {portgroup_name!r}"
+        )
+        return {**base, "status": "not_found", "candidates": [], "guidance": guidance}
     if resolution == "ambiguous":
+        moids = [c.get("network") for c in candidates if isinstance(c, dict)]
+        if backing_type == _NIC_BACKING_STANDARD_PORTGROUP:
+            guidance = (
+                f"multiple standard portgroups named {portgroup_name!r} (standard "
+                "portgroups are host-scoped -- one Network moid per host); pass the "
+                f"moid of the one on the VM's host via the 'network' param. candidates: {moids}"
+            )
+        else:
+            guidance = (
+                f"multiple distributed portgroups share the name {portgroup_name!r}; pass a "
+                f"unique name or the exact moid via the 'network' param. candidates: {moids}"
+            )
+        return {**base, "status": "ambiguous", "candidates": candidates, "guidance": guidance}
+    if resolution == "type_mismatch":
+        actual = (
+            candidates[0].get("type") if candidates and isinstance(candidates[0], dict) else None
+        )
         return {
             **base,
-            "status": "ambiguous",
+            "status": "invalid_request",
             "candidates": candidates,
-            "guidance": "multiple distributed portgroups share the name; pass a unique name",
+            "guidance": (
+                f"network moid {explicit_network!r} is a {actual!r} network, not the "
+                f"requested backing_type {backing_type!r}"
+            ),
         }
 
     gate, _ = await _write_sub_op(
@@ -7061,7 +7218,7 @@ async def vm_nic_repoint_composite(
         {
             "vm": vm_moid,
             "nic": nic_id,
-            "backing": {"type": _NETWORK_TYPE_DISTRIBUTED_PORTGROUP, "network": network_moid},
+            "backing": {"type": backing_type, "network": network_moid},
         },
     )
     if gate is not None:

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -99,7 +99,7 @@ Two preview depths, chosen per composite
   NIC backing / CD-ROM backing via the same shared helpers the handlers
   use (:func:`._write._read_vm_info` / :func:`._write._read_ethernet_nic`
   / :func:`._write._read_cdrom` /
-  :func:`._write._resolve_distributed_portgroup`) and pairs it with the
+  :func:`._write._resolve_repoint_target`) and pairs it with the
   requested change. Declines (``None`` -> identifier-only default) when no
   connector resolved or the VM read returns no dict, and fails-soft on a
   resolution fault exactly like the fan-out builders.
@@ -167,6 +167,7 @@ from meho_backplane.connectors.vmware_rest.composites._storage_policy import (
 )
 from meho_backplane.connectors.vmware_rest.composites._write import (
     _GUEST_POWER_VERBS,
+    _NIC_BACKING_DISTRIBUTED_PORTGROUP,
     _list_child_resource_pool_ids,
     _read_cdrom,
     _read_ethernet_nic,
@@ -176,8 +177,8 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     _resolve_cluster_hosts,
     _resolve_cluster_name,
     _resolve_disk_info,
-    _resolve_distributed_portgroup,
     _resolve_named_hosts_in_cluster,
+    _resolve_repoint_target,
     _resolve_vm_list,
     _resolve_vm_name,
 )
@@ -874,11 +875,12 @@ async def _vm_nic_repoint_preview(ctx: PreviewContext) -> dict[str, Any] | None:
 
     The from->to network pair is what the four-eyes reviewer needs: the
     NIC's current backing (which network it is on now) and the target
-    portgroup (name + resolved moid). Reads the NIC via
-    :func:`._write._read_ethernet_nic` and resolves the portgroup via
-    :func:`._write._resolve_distributed_portgroup` (the same helper the
-    approved dispatch binds); the VM ``name`` comes from
-    :func:`._write._read_vm_info`. No NIC PATCH fires here.
+    portgroup (``backing_type`` + resolved moid + name). Reads the NIC via
+    :func:`._write._read_ethernet_nic` and resolves the target via
+    :func:`._write._resolve_repoint_target` (the same helper the approved
+    dispatch binds, so distributed and standard portgroups preview
+    identically); the VM ``name`` comes from :func:`._write._read_vm_info`.
+    No NIC PATCH fires here.
     """
     vm = ctx.params.get("vm")
     nic = ctx.params.get("nic")
@@ -890,6 +892,9 @@ async def _vm_nic_repoint_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         or ctx.connector_instance is None
     ):
         return None
+    backing_type = ctx.params.get("backing_type", _NIC_BACKING_DISTRIBUTED_PORTGROUP)
+    network_param = ctx.params.get("network")
+    explicit_network = network_param if isinstance(network_param, str) and network_param else None
     info = await _read_vm_info(
         connector=ctx.connector_instance,  # type: ignore[arg-type]
         target=ctx.target,
@@ -903,11 +908,13 @@ async def _vm_nic_repoint_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         vm_moid=vm,
         nic_id=nic,
     )
-    network_moid, _resolution, _candidates = await _resolve_distributed_portgroup(
+    network_moid, _resolution, _candidates, resolved_name = await _resolve_repoint_target(
         connector=ctx.connector_instance,  # type: ignore[arg-type]
         target=ctx.target,
         operator=ctx.operator,
         portgroup_name=portgroup_name,
+        backing_type=backing_type,
+        explicit_network=explicit_network,
     )
     return {
         "vm": vm,
@@ -915,7 +922,11 @@ async def _vm_nic_repoint_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         "nic": nic,
         "mac_address": nic_info.get("mac_address") if nic_info else None,
         "current_backing": nic_info.get("backing") if nic_info else None,
-        "requested_backing": {"portgroup_id": network_moid, "portgroup_name": portgroup_name},
+        "requested_backing": {
+            "portgroup_id": network_moid,
+            "portgroup_name": resolved_name,
+            "backing_type": backing_type,
+        },
     }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -2960,11 +2960,13 @@ VM_RESIZE_PARAMETER_SCHEMA: dict[str, Any] = {
 
 #: ``vmware.composite.vm.nic.repoint`` parameter schema.
 #:
-#: Repoints an existing vNIC to a different distributed portgroup,
-#: resolved by display name via
-#: ``GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP`` (there is
-#: no dedicated portgroup list resource -- the #1602 reconciliation
-#: lesson). Ambiguous / missing names refuse the repoint.
+#: Repoints an existing vNIC onto a distributed **or** host-scoped standard
+#: portgroup, resolved by display name via
+#: ``GET:/vcenter/network?filter.types=<backing_type>`` (there is no
+#: dedicated portgroup list resource -- the #1602 reconciliation lesson).
+#: ``backing_type`` defaults to ``DISTRIBUTED_PORTGROUP`` (back-compatible).
+#: An explicit ``network`` moid skips name resolution. Ambiguous / missing
+#: names refuse the repoint.
 VM_NIC_REPOINT_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -2982,12 +2984,42 @@ VM_NIC_REPOINT_PARAMETER_SCHEMA: dict[str, Any] = {
             "type": "string",
             "minLength": 1,
             "description": (
-                "Display name of the target distributed portgroup. "
-                "Resolved to its network moid via "
-                "``GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP``. "
+                "Display name of the target portgroup, resolved to its "
+                "network moid via "
+                "``GET:/vcenter/network?filter.types=<backing_type>``. "
                 "A name matching zero portgroups returns "
                 "``status='not_found'``; more than one returns "
-                "``status='ambiguous'`` with the candidates listed."
+                "``status='ambiguous'`` with the candidates listed (for "
+                "host-scoped standard portgroups a name routinely matches "
+                "one moid per host -- pass ``network`` to pick one). Still "
+                "the human label the approver sees even when ``network`` is "
+                "supplied."
+            ),
+        },
+        "backing_type": {
+            "type": "string",
+            "enum": ["DISTRIBUTED_PORTGROUP", "STANDARD_PORTGROUP"],
+            "default": "DISTRIBUTED_PORTGROUP",
+            "description": (
+                "Network kind the NIC is repointed onto. "
+                "``DISTRIBUTED_PORTGROUP`` (default) targets a vDS "
+                "portgroup; ``STANDARD_PORTGROUP`` targets a host-local "
+                "standard-switch portgroup (e.g. to repair a NIC that "
+                "landed on an L2 that cannot reach its gateway). Drives "
+                "both the ``filter.types`` resolution scope and the PATCHed "
+                "``backing.type``."
+            ),
+        },
+        "network": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Explicit target ``Network`` moid. Skips name resolution "
+                "and is validated for existence + type-consistency with "
+                "``backing_type`` (a mismatch returns "
+                "``status='invalid_request'``). Required to disambiguate a "
+                "host-scoped standard portgroup whose name resolves to "
+                "several moids (``status='ambiguous'``)."
             ),
         },
     },
@@ -3110,12 +3142,16 @@ VM_NIC_REPOINT_RESPONSE_SCHEMA: dict[str, Any] = {
     "properties": {
         "status": {
             "type": "string",
-            "enum": ["repointed", "not_found", "ambiguous"],
+            "enum": ["repointed", "not_found", "ambiguous", "invalid_request"],
             "description": (
                 "``'repointed'`` -- the NIC backing was PATCHed to the "
-                "target portgroup; ``'not_found'`` -- no distributed "
-                "portgroup matched ``portgroup_name``; ``'ambiguous'`` -- "
-                "more than one did (candidates listed, no PATCH issued)."
+                "target portgroup; ``'not_found'`` -- no portgroup matched "
+                "``portgroup_name`` (or the explicit ``network`` moid did "
+                "not resolve); ``'ambiguous'`` -- more than one matched "
+                "(candidates listed -- pass ``network`` to pick one); "
+                "``'invalid_request'`` -- the explicit ``network`` moid is "
+                "the wrong network kind for ``backing_type``. No PATCH is "
+                "issued on any non-``repointed`` status."
             ),
         },
         "vm": {"type": "string", "description": "VM moid owning the NIC."},
@@ -3135,14 +3171,26 @@ VM_NIC_REPOINT_RESPONSE_SCHEMA: dict[str, Any] = {
             "properties": {
                 "portgroup_id": {"type": ["string", "null"]},
                 "portgroup_name": {"type": "string"},
+                "backing_type": {
+                    "type": "string",
+                    "enum": ["DISTRIBUTED_PORTGROUP", "STANDARD_PORTGROUP"],
+                },
             },
-            "required": ["portgroup_id", "portgroup_name"],
-            "description": "The target distributed portgroup (moid resolved from the name).",
+            "required": ["portgroup_id", "portgroup_name", "backing_type"],
+            "description": (
+                "The target portgroup the reviewer approves: ``backing_type`` "
+                "(network kind), ``portgroup_id`` (resolved moid, ``null`` "
+                "when resolution failed), and ``portgroup_name`` (display "
+                "label)."
+            ),
         },
         "candidates": {
             "type": "array",
             "items": {"type": "object"},
-            "description": "Matching portgroup rows when ``status='ambiguous'`` (empty otherwise).",
+            "description": (
+                "Matching portgroup rows when ``status='ambiguous'`` / "
+                "``'invalid_request'`` (empty otherwise)."
+            ),
         },
         "guidance": {
             "type": ["string", "null"],

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -81,7 +81,10 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_resize_composite,
     vm_snapshot_revert_composite,
 )
-from meho_backplane.connectors.vmware_rest.composites.schemas import VM_CREATE_RESPONSE_SCHEMA
+from meho_backplane.connectors.vmware_rest.composites.schemas import (
+    VM_CREATE_RESPONSE_SCHEMA,
+    VM_NIC_REPOINT_PARAMETER_SCHEMA,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -6499,6 +6502,7 @@ async def test_vm_nic_repoint_happy_path(gate: _GateRecorder) -> None:
     assert out["requested_backing"] == {
         "portgroup_id": "dvportgroup-9",
         "portgroup_name": "prod-net",
+        "backing_type": "DISTRIBUTED_PORTGROUP",
     }
     # The NIC read + the network resolve read are not gated; only the PATCH is.
     assert gate.gated_op_ids == ["PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}"]
@@ -6530,7 +6534,11 @@ async def test_vm_nic_repoint_portgroup_not_found(gate: _GateRecorder) -> None:
         connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "not_found"
-    assert out["requested_backing"] == {"portgroup_id": None, "portgroup_name": "ghost"}
+    assert out["requested_backing"] == {
+        "portgroup_id": None,
+        "portgroup_name": "ghost",
+        "backing_type": "DISTRIBUTED_PORTGROUP",
+    }
     assert gate.calls == []
 
 
@@ -6555,6 +6563,240 @@ async def test_vm_nic_repoint_ambiguous_portgroup(gate: _GateRecorder) -> None:
     assert out["status"] == "ambiguous"
     assert len(out["candidates"]) == 2
     assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_standard_portgroup_resolves_name(gate: _GateRecorder) -> None:
+    """backing_type=STANDARD_PORTGROUP resolves an unambiguous name -> standard-backed PATCH.
+
+    The same handler path the ``host.detach_from_vds`` fallback uses, now
+    reachable governed: move a NIC onto a host-local standard-switch
+    portgroup (e.g. to repair a NIC stranded on an L2 that cannot reach its
+    gateway).
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "mac_address": "00:50:56:aa:bb:cc",
+                "backing": {
+                    "type": "DISTRIBUTED_PORTGROUP",
+                    "network": "dvportgroup-1",
+                    "network_name": "old-net",
+                },
+            },
+            "/api/vcenter/network": [
+                {
+                    "network": "network-1001",
+                    "name": "mgmt-standard-pg",
+                    "type": "STANDARD_PORTGROUP",
+                }
+            ],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "mgmt-standard-pg",
+            "backing_type": "STANDARD_PORTGROUP",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "repointed"
+    assert out["requested_backing"] == {
+        "portgroup_id": "network-1001",
+        "portgroup_name": "mgmt-standard-pg",
+        "backing_type": "STANDARD_PORTGROUP",
+    }
+    assert gate.gated_op_ids == ["PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}"]
+    patch_call = next(c for c in conn.calls if c["method"] == "PATCH")
+    assert patch_call["body"] == {
+        "backing": {"type": "STANDARD_PORTGROUP", "network": "network-1001"}
+    }
+    # The name resolve scoped filter.types to STANDARD_PORTGROUP (bare on /api).
+    net_read = next(c for c in conn.calls if c["path"] == "/api/vcenter/network")
+    assert net_read["query"]["types"] == ["STANDARD_PORTGROUP"]
+    assert net_read["query"]["names"] == ["mgmt-standard-pg"]
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_standard_ambiguous_across_hosts(gate: _GateRecorder) -> None:
+    """A host-scoped standard name resolves to one moid per host -> fail-closed ambiguous.
+
+    Standard portgroups are host-scoped, so the same display name routinely
+    yields several ``Network`` moids. The REST Automation API exposes no
+    reliable VM->host mapping, so the composite fails closed and the
+    remediation points the operator at the explicit ``network`` param.
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {"mac_address": "aa", "backing": {}},
+            "/api/vcenter/network": [
+                {"network": "network-1001", "name": "svc-net", "type": "STANDARD_PORTGROUP"},
+                {"network": "network-1002", "name": "svc-net", "type": "STANDARD_PORTGROUP"},
+            ],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "svc-net",
+            "backing_type": "STANDARD_PORTGROUP",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ambiguous"
+    assert {c["network"] for c in out["candidates"]} == {"network-1001", "network-1002"}
+    # The remediation names the host-scoped cause and the escape-hatch param.
+    assert "host-scoped" in out["guidance"]
+    assert "network" in out["guidance"]
+    assert "network-1001" in out["guidance"] and "network-1002" in out["guidance"]
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_explicit_network_moid(gate: _GateRecorder) -> None:
+    """An explicit network moid skips name resolution and PATCHes after a type check.
+
+    This is how the operator resolves the host-scoped ambiguity above: pass
+    the moid of the standard portgroup on the VM's host directly.
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "mac_address": "00:50:56:aa:bb:cc",
+                "backing": {"type": "DISTRIBUTED_PORTGROUP", "network": "dvportgroup-1"},
+            },
+            "/api/vcenter/network": [
+                {"network": "network-1001", "name": "svc-net", "type": "STANDARD_PORTGROUP"},
+                {"network": "network-1002", "name": "svc-net", "type": "STANDARD_PORTGROUP"},
+            ],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "svc-net",
+            "backing_type": "STANDARD_PORTGROUP",
+            "network": "network-1002",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "repointed"
+    assert out["requested_backing"] == {
+        "portgroup_id": "network-1002",
+        "portgroup_name": "svc-net",
+        "backing_type": "STANDARD_PORTGROUP",
+    }
+    patch_call = next(c for c in conn.calls if c["method"] == "PATCH")
+    assert patch_call["body"] == {
+        "backing": {"type": "STANDARD_PORTGROUP", "network": "network-1002"}
+    }
+    # The validation read filtered by moid (filter.networks -> bare on /api),
+    # never by name -- proving name resolution was skipped.
+    net_read = next(c for c in conn.calls if c["path"] == "/api/vcenter/network")
+    assert net_read["query"] == {"networks": ["network-1002"]}
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_explicit_network_type_mismatch(gate: _GateRecorder) -> None:
+    """An explicit moid of the wrong network kind for backing_type -> invalid_request; no PATCH."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {"mac_address": "aa", "backing": {}},
+            "/api/vcenter/network": [
+                {"network": "dvportgroup-9", "name": "prod-net", "type": "DISTRIBUTED_PORTGROUP"}
+            ],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "prod-net",
+            "backing_type": "STANDARD_PORTGROUP",
+            "network": "dvportgroup-9",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "invalid_request"
+    assert out["candidates"][0]["network"] == "dvportgroup-9"
+    assert "STANDARD_PORTGROUP" in out["guidance"]
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_explicit_network_not_found(gate: _GateRecorder) -> None:
+    """An explicit moid that resolves to no network row -> not_found; no PATCH."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {"mac_address": "aa", "backing": {}},
+            "/api/vcenter/network": [],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "svc-net",
+            "backing_type": "STANDARD_PORTGROUP",
+            "network": "network-9999",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "not_found"
+    assert "network-9999" in out["guidance"]
+    assert gate.calls == []
+
+
+def test_vm_nic_repoint_parameter_schema_accepts_backing_type() -> None:
+    """The parameter schema admits both backing types + an explicit network, rejects junk."""
+    validator = Draft202012Validator(VM_NIC_REPOINT_PARAMETER_SCHEMA)
+    # Back-compatible minimal call (no backing_type) still validates.
+    validator.validate({"vm": "vm-1", "nic": "4000", "portgroup_name": "prod-net"})
+    # Both enum values validate; the explicit network moid is accepted.
+    validator.validate(
+        {
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "prod-net",
+            "backing_type": "DISTRIBUTED_PORTGROUP",
+        }
+    )
+    validator.validate(
+        {
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "svc-net",
+            "backing_type": "STANDARD_PORTGROUP",
+            "network": "network-1001",
+        }
+    )
+    # An out-of-enum backing_type is rejected.
+    with pytest.raises(ValidationError):
+        validator.validate(
+            {
+                "vm": "vm-1",
+                "nic": "4000",
+                "portgroup_name": "prod-net",
+                "backing_type": "OPAQUE_NETWORK",
+            }
+        )
+    # additionalProperties:False still rejects unknown keys.
+    with pytest.raises(ValidationError):
+        validator.validate({"vm": "vm-1", "nic": "4000", "portgroup_name": "prod-net", "bogus": 1})
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -2131,6 +2131,7 @@ async def test_vm_nic_repoint_sub_op_sequence(
     assert result.result["requested_backing"] == {
         "portgroup_id": "dvportgroup-9",
         "portgroup_name": "prod-pg",
+        "backing_type": "DISTRIBUTED_PORTGROUP",
     }
     assert recorder.calls == [
         ("GET", "/vcenter/vm/vm-1/hardware/ethernet/4000"),

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -1380,13 +1380,111 @@ async def test_vm_nic_repoint_preview_reads_backing_and_resolves_portgroup() -> 
             "network": "dvportgroup-1",
             "network_name": "old-net",
         },
-        "requested_backing": {"portgroup_id": "dvportgroup-9", "portgroup_name": "prod-net"},
+        "requested_backing": {
+            "portgroup_id": "dvportgroup-9",
+            "portgroup_name": "prod-net",
+            "backing_type": "DISTRIBUTED_PORTGROUP",
+        },
     }
     assert recorder.specs == [
         "/vcenter/vm/vm-1",
         "/vcenter/vm/vm-1/hardware/ethernet/4000",
         "/vcenter/network",
     ]
+
+
+async def test_vm_nic_repoint_preview_standard_portgroup_resolves_name() -> None:
+    """The NIC preview reflects backing_type=STANDARD_PORTGROUP and resolves the name."""
+    recorder = _RecordingConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1": {"value": {"name": "web-1"}},
+            "/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "value": {
+                    "mac_address": "00:50:56:aa:bb:cc",
+                    "backing": {
+                        "type": "DISTRIBUTED_PORTGROUP",
+                        "network": "dvportgroup-1",
+                        "network_name": "old-net",
+                    },
+                }
+            },
+            "/vcenter/network": {
+                "value": [
+                    {
+                        "network": "network-1001",
+                        "name": "mgmt-standard-pg",
+                        "type": "STANDARD_PORTGROUP",
+                    }
+                ]
+            },
+        }
+    )
+    preview = await _write_preview._vm_nic_repoint_preview(
+        _make_preview_ctx(
+            {
+                "vm": "vm-1",
+                "nic": "4000",
+                "portgroup_name": "mgmt-standard-pg",
+                "backing_type": "STANDARD_PORTGROUP",
+            },
+            connector_instance=recorder,
+        )
+    )
+    assert preview is not None
+    assert preview["current_backing"]["network"] == "dvportgroup-1"
+    assert preview["requested_backing"] == {
+        "portgroup_id": "network-1001",
+        "portgroup_name": "mgmt-standard-pg",
+        "backing_type": "STANDARD_PORTGROUP",
+    }
+    assert recorder.specs == [
+        "/vcenter/vm/vm-1",
+        "/vcenter/vm/vm-1/hardware/ethernet/4000",
+        "/vcenter/network",
+    ]
+
+
+async def test_vm_nic_repoint_preview_explicit_network_moid() -> None:
+    """The preview honours an explicit network moid (validate-by-moid, no name resolve)."""
+    recorder = _RecordingConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1": {"value": {"name": "web-1"}},
+            "/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "value": {
+                    "mac_address": "00:50:56:aa:bb:cc",
+                    "backing": {"type": "DISTRIBUTED_PORTGROUP", "network": "dvportgroup-1"},
+                }
+            },
+            "/vcenter/network": {
+                "value": [
+                    {"network": "network-1002", "name": "svc-net", "type": "STANDARD_PORTGROUP"}
+                ]
+            },
+        }
+    )
+    preview = await _write_preview._vm_nic_repoint_preview(
+        _make_preview_ctx(
+            {
+                "vm": "vm-1",
+                "nic": "4000",
+                "portgroup_name": "svc-net",
+                "backing_type": "STANDARD_PORTGROUP",
+                "network": "network-1002",
+            },
+            connector_instance=recorder,
+        )
+    )
+    assert preview is not None
+    assert preview["requested_backing"] == {
+        "portgroup_id": "network-1002",
+        "portgroup_name": "svc-net",
+        "backing_type": "STANDARD_PORTGROUP",
+    }
+    # The network read filtered by moid (filter.networks -> bare on /api), never by name.
+    net_read = next(q for spec, q in recorder.read_calls if spec == "/vcenter/network")
+    assert net_read == {"networks": ["network-1002"]}
 
 
 async def test_vm_device_cdrom_preview_live_reads_current_backing() -> None:
@@ -1519,7 +1617,11 @@ async def test_vm_nic_repoint_park_carries_network_from_to_pair(
             "nic": "4000",
             "mac_address": "aa:bb",
             "current_backing": {"type": "STANDARD_PORTGROUP"},
-            "requested_backing": {"portgroup_id": "dvportgroup-9", "portgroup_name": "prod-net"},
+            "requested_backing": {
+                "portgroup_id": "dvportgroup-9",
+                "portgroup_name": "prod-net",
+                "backing_type": "DISTRIBUTED_PORTGROUP",
+            },
         },
         "preview_populated": True,
         "safety_level": "dangerous",

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -721,7 +721,12 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
         },
         "vmware.composite.cluster.patch": {"completed", "stopped"},
         "vmware.composite.vm.resize": {"resized", "requires_power_off", "no_change", "partial"},
-        "vmware.composite.vm.nic.repoint": {"repointed", "not_found", "ambiguous"},
+        "vmware.composite.vm.nic.repoint": {
+            "repointed",
+            "not_found",
+            "ambiguous",
+            "invalid_request",
+        },
         "vmware.composite.vm.device.cdrom": {
             "removed",
             "updated",

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -980,7 +980,7 @@ enum) are:
 | `network.portgroup.create` | `created`, `invalid_vlan_spec`, `timeout` (vim `CreateDVPortgroup_Task` polled, #3091; `invalid_vlan_spec` refuses a trunk+access clash before any write; `timeout` when the poll gives up; a task *fault* — e.g. `DuplicateName` — raises `connector_error`. The `created` envelope carries a read-back `observed` = `{name, vlan}` off the new portgroup's `config`. The trunk / access VLAN specs are `InheritablePolicy` subtypes, so each wire body carries `inherited: false` — without it vCenter defaults `inherited: true` and drops the `vlanId`, silently creating an untagged (VLAN 0) portgroup, #3356) |
 | `network.portgroup.security.set` | `updated`, `no_change_requested`, `timeout` (vim `ReconfigureDVPortgroup_Task` polled, #3091; `no_change_requested` refuses when none of the three booleans is supplied, before any read/write; `timeout` when the poll gives up; a task *fault* raises `connector_error`. Carries `previous` (pre-write security triple) + `observed` (post-write triple) read-backs) |
 | `vm.resize` | `resized`, `requires_power_off`, `no_change`, `partial` |
-| `vm.nic.repoint` | `repointed`, `not_found`, `ambiguous` |
+| `vm.nic.repoint` | `repointed`, `not_found`, `ambiguous`, `invalid_request` |
 | `vm.device.cdrom` | `removed`, `updated`, `disconnected`, `invalid_request` |
 
 `vm.create` is the only composite that issues a compensating
@@ -1011,12 +1011,23 @@ a host-pinning ISO:
   the operator gets a typed status instead of a raw vCenter 400.
 - **`vm.nic.repoint`** reads the NIC's current backing + MAC via
   `GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}`, resolves the target
-  distributed portgroup by display name via
-  `GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP`, then PATCHes
+  portgroup by display name via
+  `GET:/vcenter/network?filter.types=<backing_type>`, then PATCHes
   `PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}` with
-  `{backing: {type: DISTRIBUTED_PORTGROUP, network: <moid>}}`. A name
-  that matches zero / many portgroups refuses the repoint
-  (`not_found` / `ambiguous`) with no PATCH issued.
+  `{backing: {type: backing_type, network: <moid>}}` — the same internal
+  sub-op the `host.detach_from_vds` fallback path uses. `backing_type` is
+  `DISTRIBUTED_PORTGROUP` (default, back-compatible) or
+  `STANDARD_PORTGROUP`; the latter moves a NIC onto a host-local
+  standard-switch portgroup (e.g. to repair a NIC stranded on an L2 that
+  cannot reach its gateway). Standard portgroups are host-scoped, so one
+  display name routinely resolves to several `Network` moids (one per
+  host) and the REST Automation API exposes no reliable VM->host mapping,
+  so an ambiguous name fails closed (`ambiguous`, candidate moids listed)
+  and the operator supplies the exact moid via the `network` param. An
+  explicit `network` moid skips name resolution and is validated for
+  existence + type-consistency with `backing_type` (`invalid_request` on
+  mismatch); a name matching zero portgroups returns `not_found`. No PATCH
+  is issued on any non-`repointed` status.
 - **`vm.device.cdrom`** reads the device's current backing + state via
   `GET:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}` (surfacing a host-local
   ISO path the approver needs to see), then dispatches the `action`:
@@ -1955,7 +1966,7 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `host.detach_from_vds` | `{host, dvs, fallback_network, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
 | `cluster.patch` | `{cluster, resolved, total_resolved}` | live read (`GET:/vcenter/host?clusters=...`) |
 | `vm.resize` | `{vm, name, power_state, current, requested}` sizing from->to | live read (`GET:/vcenter/vm/{vm}`) |
-| `vm.nic.repoint` | `{vm, name, nic, mac_address, current_backing, requested_backing}` network from->to | live read (`ethernet/{nic}` + `GET:/vcenter/network`) |
+| `vm.nic.repoint` | `{vm, name, nic, mac_address, current_backing, requested_backing}` network from->to (`requested_backing` carries `backing_type`, so distributed and standard previews are identical) | live read (`ethernet/{nic}` + `GET:/vcenter/network`) |
 | `vm.device.cdrom` | `{vm, name, cdrom, action, current_backing, state}` (the host-local ISO path) | live read (`cdrom/{cdrom}`) |
 | `vm.create` | creation-spec echo (name, guest_os, placement pins — folder_name, folder (#3115), resource_pool, datastore, host (#3096) — sizing, networks, disks_gb (#3117), nested_hv, power-on) | param echo, no I/O |
 | `vm.clone` | clone-coordinates echo | param echo, no I/O |


### PR DESCRIPTION
Closes #3561

## What

`vmware.composite.vm.nic.repoint` (`vmware-rest-9.0`) could only move a vNIC
onto a **distributed** portgroup — its PATCH backing was hard-coded to
`{type: DISTRIBUTED_PORTGROUP, network}`. This adds the ability to repoint a
NIC onto a host-scoped **standard** portgroup, governed.

## Why

An operator must be able to move a VM NIC between a distributed portgroup and
a host-scoped standard portgroup through the backplane — for example, to
repair a VM whose NIC landed on an L2 segment that does not reach its
gateway. Before this change that repair was only possible out of band,
outside the audit/approval path. The plumbing already existed internally: the
`host.detach_from_vds` fallback builds `{type: STANDARD_PORTGROUP, network}`
and sends it through the very same internal NIC-PATCH sub-op; the composite
simply did not expose that backing type.

## How

- New optional param **`backing_type`** enum `[DISTRIBUTED_PORTGROUP,
  STANDARD_PORTGROUP]`, default `DISTRIBUTED_PORTGROUP` — the existing
  distributed path is byte-for-byte back-compatible.
- The name is resolved via `GET:/vcenter/network` scoped to `backing_type`,
  and the PATCH sends `{type: backing_type, network}` through the same
  internal sub-op the fallback path uses. **No new sub-op is introduced.**
- Standard portgroups are host-scoped, so one display name routinely resolves
  to several `Network` moids (one per host), and the REST Automation API
  exposes no reliable VM→host mapping. An ambiguous standard-portgroup name
  therefore **fails closed** (`status='ambiguous'`) with the candidate moids
  listed and a remediation that names the host-scoped cause.
- New optional param **`network`** (a `Network` moid): skips name resolution
  and is validated for existence + type-consistency with `backing_type`
  (`status='invalid_request'` on mismatch). This is how the operator resolves
  the host-scoped ambiguity above.
- The **preview builder** mirrors the handler, so the four-eyes approver sees
  `current_backing → requested_backing` (type + network + name) for both
  backing types. `safety_level` stays `dangerous` / `requires_approval`.

## Surface / schema changes

- `parameter_schema`: `backing_type` (enum, default distributed) and
  `network` (moid) added, both optional; `required` unchanged
  (`vm`/`nic`/`portgroup_name`); `additionalProperties:false` preserved.
- `response_schema`: `status` gains `invalid_request`; `requested_backing`
  gains `backing_type`.
- Registration summary/description and `docs/codebase/connectors-vmware-rest.md`
  updated; the status-enum op-inventory pin updated.

## Tests

New unit tests with the existing fake vCenter fixtures cover: default
distributed path unchanged; standard unambiguous name resolve; ambiguous
name across hosts → fail-closed with candidates; explicit network moid path;
type mismatch → `invalid_request`; explicit-moid not-found; preview builder
output for both backing types; and parameter-schema validation of
`backing_type`.

Local runs (worktree venv):

- All `vmware_rest_composites` modules: **503 passed, 23 skipped**.
- Conformance / inventory / drift set (`reference_docs_drift`,
  `maturity_surface_drift`, `mcp_surface_conformance`,
  `mcp_output_schema_conformance`, `destructive_builder_conformance`,
  `l2_ingest_reconcile`): **91 passed, 18 skipped**.
- `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
